### PR TITLE
Initial working version of querying a few global metrics

### DIFF
--- a/db/instance.go
+++ b/db/instance.go
@@ -17,6 +17,10 @@ type Instance struct {
 	id string
 }
 
+func NewInstance(db *sql.DB, id string) Instance {
+	return Instance{db, id}
+}
+
 func (in *Instance) Id() string {
 	return in.id
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/square/blip
 
 go 1.16
+
+require (
+	github.com/go-sql-driver/mysql v1.6.0
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/metrics/var/global.go
+++ b/metrics/var/global.go
@@ -2,30 +2,44 @@ package sysvar
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+
+	_ "github.com/go-sql-driver/mysql"
 
 	"github.com/square/blip/collect"
 	"github.com/square/blip/db"
 )
 
 const (
-	OPT_SOURCE = "source"
+	OPT_SOURCE    = "source"
+	SOURCE_SELECT = "select"
+	SOURCE_PFS    = "pfs"
+	SOURCE_SHOW   = "show"
 )
+
+var validMetricRegex = regexp.MustCompile("^[a-zA-Z0-9_-]*$")
 
 // Global collects global system variables for the var.global domain.
 type Global struct {
-	in    db.Instance
-	plans collect.Plan
-	// --
-	domain string
-	workIn map[string][]string
+	in       db.Instance
+	plans    collect.Plan
+	domain   string
+	workIn   map[string][]string
+	queryIn  map[string]string
+	sourceIn map[string]string
 }
 
 func NewGlobal(in db.Instance) *Global {
 	return &Global{
-		in: in,
-		// --
-		domain: "var.global",
-		workIn: map[string][]string{},
+		in:       in,
+		domain:   "var.global",
+		workIn:   map[string][]string{},
+		queryIn:  make(map[string]string),
+		sourceIn: make(map[string]string),
 	}
 }
 
@@ -41,12 +55,72 @@ func (c *Global) Help() collect.Help {
 			{
 				OPT_SOURCE,
 				"Where to collect sysvars from",
-				"auto (auto-determine best source); pfs (performance_schema.global_variables); show (SHOW GLOBAL STATUS)",
+				"auto (auto-determine best source); select (@@GLOBAL.metric_name); pfs (performance_schema.global_variables); show (SHOW GLOBAL STATUS)",
 			},
 		},
 	}
 }
 
+// Prepares the query for given level based on it's metrics and source option
+func (c *Global) prepareLevel(levelName string, metrics []string, options map[string]string) error {
+
+	// Reset in case because prepareLevel can be called multiple times
+	// if the LPA changes the plan
+	c.sourceIn[levelName] = ""
+	c.queryIn[levelName] = ""
+	c.workIn[levelName] = []string{}
+
+	// Validate the metricnames for the level
+	err := validateMetricNames(metrics)
+	if err != nil {
+		return err
+	}
+
+	// Save metrics to collect for this level
+	c.workIn[levelName] = append(c.workIn[levelName], metrics...)
+
+	// -------------------------------------------------------------------------
+	// Manual source
+	// -------------------------------------------------------------------------
+
+	// If user specified a method, use only that method, whether it works or not
+	if options != nil {
+		src := options[OPT_SOURCE]
+
+		if len(src) > 0 && src != "auto" {
+			switch src {
+			case SOURCE_SELECT:
+				return c.prepareSELECT(levelName)
+			case SOURCE_PFS:
+				return c.preparePFS(levelName)
+			case SOURCE_SHOW:
+				return c.prepareSHOW(levelName)
+			default:
+				return fmt.Errorf("invalid source: %s; valid values: auto, select, pfs, show", src)
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Auto source (default)
+	// -------------------------------------------------------------------------
+
+	if err = c.prepareSELECT(levelName); err == nil {
+		return nil
+	}
+
+	if err = c.preparePFS(levelName); err == nil {
+		return nil
+	}
+
+	if err = c.prepareSHOW(levelName); err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("auto source failed, last error: %s", err)
+}
+
+// Prepares queries for all levels in the plan that contain the "var.global" domain
 func (c *Global) Prepare(plan collect.Plan) error {
 LEVEL:
 	for levelName, level := range plan.Levels {
@@ -55,45 +129,157 @@ LEVEL:
 			// This domain not collected in this level
 			continue LEVEL
 		}
-
-		// Handle options, if any
-		if dom.Options != nil {
-			if src, _ := dom.Options[OPT_SOURCE]; ok {
-				switch src {
-				case "auto", "":
-				case "pfs":
-				case "show":
-				default:
-					// @todo: error, invalid option
-				}
-			}
+		err := c.prepareLevel(levelName, dom.Metrics, dom.Options)
+		if err != nil {
+			// return early with error even if preparing a single level fails
+			return err
 		}
-
-		// Save metrics to collect for this level
-		c.workIn[levelName] = make([]string, len(dom.Metrics))
-		copy(c.workIn[levelName], dom.Metrics)
-
-		// Prepare satements for collecting metrics?
 	}
-
 	return nil
 }
 
 func (c *Global) Collect(ctx context.Context, levelName string) (collect.Metrics, error) {
-	//dom := level[c.domain]
+	switch c.sourceIn[levelName] {
+	case SOURCE_SELECT:
+		return c.collectSELECT(ctx, levelName)
+	case SOURCE_PFS:
+		return c.collectPFS(ctx, levelName)
+	case SOURCE_SHOW:
+		return c.collectSHOW(ctx, levelName)
+	}
 
-	rows, err := c.in.DB().QueryContext(ctx, "SHOW GLOBAL VARIABLES")
+	errorStr := fmt.Sprintf("invalid source in Collect %s", c.sourceIn[levelName])
+	panic(errorStr)
+}
+
+// Validate input metric names to make sure there won't be any
+// sql injection attacks.
+func validateMetricNames(metricNames []string) error {
+	for _, name := range metricNames {
+		if !validMetricRegex.MatchString(name) {
+			return fmt.Errorf("%s metric isn't a valid metric name", name)
+		}
+	}
+	return nil
+}
+
+func (c *Global) prepareSELECT(levelName string) error {
+	var globalMetrics = make([]string, len(c.workIn[levelName]))
+
+	for i, str := range c.workIn[levelName] {
+		globalMetrics[i] = fmt.Sprintf("@@GLOBAL.%s", str)
+	}
+	globalMetricString := strings.Join(globalMetrics, ", ")
+
+	c.queryIn[levelName] = fmt.Sprintf("SELECT CONCAT_WS(',', %s) AS globalvalue;", globalMetricString)
+	c.sourceIn[levelName] = SOURCE_SELECT
+
+	// Try collecting, discard metrics
+	_, err := c.collectSELECT(context.TODO(), levelName)
+	return err
+}
+
+func (c *Global) collectSELECT(ctx context.Context, levelName string) (collect.Metrics, error) {
+	rows, err := c.in.DB().QueryContext(ctx, c.queryIn[levelName])
 	if err != nil {
 		return collect.Metrics{}, err
 	}
 	defer rows.Close()
 
+	var metrics = new(collect.Metrics)
+	metrics.Values = make(map[string]float64)
+	var val string
+
 	for rows.Next() {
-		var name, val string
-		if err := rows.Scan(&name, &val); err != nil {
-			// @todo
+
+		if err := rows.Scan(&val); err != nil {
+			log.Println(err)
+			// Log error and continue to next row to retrieve next metric
+			continue
 		}
+
+		values := strings.Split(val, ",")
+		for idx, name := range c.workIn[levelName] {
+			s, err := strconv.ParseFloat(values[idx], 64)
+			if err != nil {
+				log.Printf("Error parsing the metric: %s value: %s as float %s", name, val, err)
+				// Log error and continue to next row to retrieve next metric
+				continue
+			}
+			metrics.Values[name] = s
+		}
+
+	}
+	// Check if there were any errors when retrieving rows and return
+	err = rows.Err()
+	return *metrics, err
+}
+
+func (c *Global) preparePFS(levelName string) error {
+	var metricString string
+	metricString = strings.Join(c.workIn[levelName], "', '")
+
+	query := fmt.Sprintf("SELECT variable_name, variable_value from performance_schema.global_variables WHERE variable_name in ('%s');",
+		metricString,
+	)
+	c.queryIn[levelName] = query
+	c.sourceIn[levelName] = SOURCE_PFS
+
+	// Try collecting, discard metrics
+	_, err := c.collectPFS(context.TODO(), levelName)
+	return err
+}
+
+func (c *Global) collectPFS(ctx context.Context, levelName string) (collect.Metrics, error) {
+	return c.collectSHOWorPFS(ctx, levelName)
+}
+
+func (c *Global) prepareSHOW(levelName string) error {
+	metricString := strings.Join(c.workIn[levelName], "', '")
+	query := fmt.Sprintf("SHOW GLOBAL VARIABLES WHERE variable_name in ('%s');", metricString)
+
+	c.queryIn[levelName] = query
+	c.sourceIn[levelName] = SOURCE_SHOW
+
+	// Try collecting, discard metrics
+	_, err := c.collectPFS(context.TODO(), levelName)
+	return err
+}
+
+func (c *Global) collectSHOW(ctx context.Context, levelName string) (collect.Metrics, error) {
+	return c.collectSHOWorPFS(ctx, levelName)
+}
+
+// Since both `show` and `pfs` queries return results in same format (ie; 2 columns, name and value)
+// use the same logic for querying and retrieving metrics from the results
+func (c *Global) collectSHOWorPFS(ctx context.Context, levelName string) (collect.Metrics, error) {
+	rows, err := c.in.DB().QueryContext(ctx, c.queryIn[levelName])
+	if err != nil {
+		return collect.Metrics{}, err
+	}
+	defer rows.Close()
+
+	var metrics = new(collect.Metrics)
+	metrics.Values = make(map[string]float64)
+	var name, val string
+
+	for rows.Next() {
+		if err := rows.Scan(&name, &val); err != nil {
+			log.Printf("Error scanning row %s", err)
+			// Log error and continue to next row to retrieve next metric
+			continue
+		}
+
+		s, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			log.Printf("Error parsing the metric: %s value: %s as float %s", name, val, err)
+			// Log error and continue to next row to retrieve next metric
+			continue
+		}
+		metrics.Values[name] = s
 	}
 
-	return collect.Metrics{}, nil
+	// Check if there were any errors when retrieving rows and return
+	err = rows.Err()
+	return *metrics, err
 }

--- a/metrics/var/global_test.go
+++ b/metrics/var/global_test.go
@@ -1,0 +1,261 @@
+package sysvar
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/square/blip/collect"
+	blipdb "github.com/square/blip/db"
+)
+
+func createDomain(domainName string, metrics []string, sourceOption ...string) map[string]collect.Domain {
+	domainMap := make(map[string]collect.Domain)
+	if len(sourceOption) >= 1 {
+		domainMap[domainName] = collect.Domain{domainName, make(map[string]string), metrics}
+		domainMap[domainName].Options["source"] = sourceOption[0]
+	} else {
+		domainMap[domainName] = collect.Domain{domainName, nil, metrics}
+	}
+	return domainMap
+}
+
+func createLevel(levelName string, frequency string, domain map[string]collect.Domain) *collect.Level {
+	return &collect.Level{
+		levelName,
+		frequency,
+		domain,
+	}
+}
+
+func createPlan(planName string, levelNames []string, levels []collect.Level) *collect.Plan {
+	lvls := make(map[string]collect.Level)
+	for i, name := range levelNames {
+		lvls[name] = levels[i]
+	}
+	return &collect.Plan{planName, lvls}
+}
+
+// First Method that gets run before all tests.
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	os.Exit(code)
+}
+
+var globalCollector *Global
+
+func setup() {
+	dsn := fmt.Sprintf(
+		"%s:%s@tcp(%s:%s)/?parseTime=true",
+		"root",
+		"test",
+		"localhost",
+		"33570",
+	)
+	dbIns, err := sql.Open("mysql", dsn)
+	if err != nil {
+		panic(err)
+	}
+	err = dbIns.Ping()
+	if err != nil {
+		log.Fatalf("Unable to ping the database dsn: %s", dsn)
+	}
+
+	globalCollector = NewGlobal(blipdb.NewInstance(dbIns, "test"))
+}
+
+func TestPrepareForSingleLevelAndNoSource(t *testing.T) {
+
+	// Given a LevelPlan for a collector with single level and no supplied source,
+	// test that Prepare correctly constructs the query for that level (ie: select query)
+
+	domain := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"})
+	level := createLevel("vars", "10s", domain)
+	plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+
+	err := globalCollector.Prepare(*plan)
+	if err != nil {
+		assert.Fail(t, fmt.Sprint("Unable to prepare the collector for metric collection", globalCollector, err))
+	}
+
+	assert.Equal(t,
+		"SELECT "+
+			"CONCAT_WS(',', @@GLOBAL.max_connections, @@GLOBAL.max_prepared_stmt_count,"+
+			" @@GLOBAL.innodb_log_file_size, @@GLOBAL.innodb_max_dirty_pages_pct) AS globalvalue;",
+		globalCollector.queryIn["vars"],
+	)
+}
+
+func TestPreparewithAllSources(t *testing.T) {
+	// Given a LevelPlan for a collector with single level and a custom source,
+	// test that Prepare correctly constructs the query for that level
+	// using that source query.
+
+	// Test this for all source types ie; auto, select, pfs and show
+
+	queries := map[string]string{
+		"auto": "SELECT " +
+			"CONCAT_WS(',', @@GLOBAL.max_connections, @@GLOBAL.max_prepared_stmt_count, " +
+			"@@GLOBAL.innodb_log_file_size, @@GLOBAL.innodb_max_dirty_pages_pct) AS globalvalue;",
+
+		"select": "SELECT " +
+			"CONCAT_WS(',', @@GLOBAL.max_connections, @@GLOBAL.max_prepared_stmt_count, " +
+			"@@GLOBAL.innodb_log_file_size, @@GLOBAL.innodb_max_dirty_pages_pct) AS globalvalue;",
+
+		"pfs": "SELECT variable_name, variable_value " +
+			"from performance_schema.global_variables " +
+			"WHERE variable_name in ('max_connections', 'max_prepared_stmt_count', " +
+			"'innodb_log_file_size', 'innodb_max_dirty_pages_pct');",
+
+		"show": "SHOW GLOBAL VARIABLES " +
+			"WHERE variable_name " +
+			"in ('max_connections', 'max_prepared_stmt_count', " +
+			"'innodb_log_file_size', 'innodb_max_dirty_pages_pct');",
+	}
+
+	for src, query := range queries {
+		domain := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"}, src)
+		level := createLevel("vars", "10s", domain)
+		plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+		err := globalCollector.Prepare(*plan)
+		if err != nil {
+			assert.Fail(t, fmt.Sprint("Unable to prepare the collector for metric collection", globalCollector, err))
+		}
+
+		assert.Equal(t,
+			query,
+			globalCollector.queryIn["vars"],
+		)
+	}
+}
+
+func TestPreparewithCustomInvalidSource(t *testing.T) {
+
+	// Given a LevelPlan for a collector with single level and a custom source,
+	// which is invalid, test that Prepare returns an error
+
+	domain := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"}, "shadow")
+	level := createLevel("vars", "10s", domain)
+	plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+	err := globalCollector.Prepare(*plan)
+	assert.Error(t, err)
+}
+
+func TestPreparewithInvalidMetricName(t *testing.T) {
+
+	// Given a LevelPlan for a collector with single level and
+	// invalid metricname, test that Prepare returns an error
+
+	domain := createDomain("var.global", []string{"max_connections'); DROP TABLE students;--,", "max_prepared_stmt_count"})
+	level := createLevel("vars", "10s", domain)
+	plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+	err := globalCollector.Prepare(*plan)
+	assert.Error(t, err)
+}
+
+func TestCollectWithSingleLevelPlanAndNoSource(t *testing.T) {
+
+	// Given a plan with single level containing a list of metrics for domain
+	// and no custom source, verify that those metrics are retrieved correctly.
+
+	domain := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"})
+	level := createLevel("vars", "10s", domain)
+	plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+
+	err := globalCollector.Prepare(*plan)
+
+	if err != nil {
+		assert.Fail(t, fmt.Sprint("Unable to prepare the collector for metric collection", globalCollector, err))
+	}
+	metrics, _ := globalCollector.Collect(context.TODO(), "vars")
+	metricKeys := make([]string, 0, len(metrics.Values))
+	for k, _ := range metrics.Values {
+		metricKeys = append(metricKeys, k)
+	}
+	assert.ElementsMatch(t, metricKeys, []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"})
+}
+
+func TestCollectWithAllSources(t *testing.T) {
+
+	// Given a level plan with custom source option
+	// collect should return the list of metrics correctly.
+
+	// Test this for all source types ie; auto, select, pfs and show
+
+	srcs := [4]string{"auto", "select", "pfs", "show"}
+
+	for _, src := range srcs {
+		domain := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"}, src)
+		level := createLevel("vars", "10s", domain)
+		plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+
+		err := globalCollector.Prepare(*plan)
+		if err != nil {
+			assert.Fail(t, fmt.Sprintf("Unable to prepare the collector for metric collection for source: %s", src), err)
+		}
+		metrics, _ := globalCollector.Collect(context.TODO(), "vars")
+		metricKeys := make([]string, 0, len(metrics.Values))
+		for k, _ := range metrics.Values {
+			metricKeys = append(metricKeys, k)
+		}
+		assert.ElementsMatch(t, metricKeys, []string{"max_connections", "max_prepared_stmt_count", "innodb_log_file_size", "innodb_max_dirty_pages_pct"})
+	}
+}
+
+func TestCollectWithMultipleLevels(t *testing.T) {
+
+	// Given a plan with multiple levels containing a list of metrics for each level
+	// verify that those metrics are retrieved correctly only at their respective levels.
+
+	domain1 := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count"})
+	domain2 := createDomain("var.global", []string{"innodb_log_file_size", "innodb_max_dirty_pages_pct"})
+	level1 := createLevel("vars1", "10s", domain1)
+	level2 := createLevel("vars2", "10s", domain2)
+	plan := createPlan("testPlan", []string{"vars1", "vars2"}, []collect.Level{*level1, *level2})
+
+	err := globalCollector.Prepare(*plan)
+	if err != nil {
+		assert.Fail(t, fmt.Sprint("Unable to prepare the collector for metric collection", globalCollector, err))
+	}
+	metrics, _ := globalCollector.Collect(context.TODO(), "vars1")
+	metricKeys := make([]string, 0, len(metrics.Values))
+	for k, _ := range metrics.Values {
+		metricKeys = append(metricKeys, k)
+	}
+	assert.ElementsMatch(t, metricKeys, []string{"max_connections", "max_prepared_stmt_count"})
+
+	metrics, _ = globalCollector.Collect(context.TODO(), "vars2")
+	metricKeys = make([]string, 0, len(metrics.Values))
+	for k, _ := range metrics.Values {
+		metricKeys = append(metricKeys, k)
+	}
+	assert.ElementsMatch(t, metricKeys, []string{"innodb_log_file_size", "innodb_max_dirty_pages_pct"})
+}
+
+func TestCollectWithOneNonExistentMetric(t *testing.T) {
+
+	// Given a level plan with single level which contains 3 valid metrics and
+	// 1 non existent metric, it should successfully return 3 metrics
+
+	domain := createDomain("var.global", []string{"max_connections", "max_prepared_stmt_count", "non_existent_metric", "innodb_max_dirty_pages_pct"})
+	level := createLevel("vars", "10s", domain)
+	plan := createPlan("testPlan", []string{"vars"}, []collect.Level{*level})
+
+	err := globalCollector.Prepare(*plan)
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("Unable to prepare the collector for metric collection"))
+	}
+	metrics, _ := globalCollector.Collect(context.TODO(), "vars")
+	metricKeys := make([]string, 0, len(metrics.Values))
+	for k, _ := range metrics.Values {
+		metricKeys = append(metricKeys, k)
+	}
+	assert.ElementsMatch(t, metricKeys, []string{"max_connections", "max_prepared_stmt_count", "innodb_max_dirty_pages_pct"})
+}


### PR DESCRIPTION
First version of implementing global collector:

- Defaults to using @@GLOBAL.metric_name unless level plan provides a different option ie: `show` or `pfs`.
- For the default , If for some reason @@GLOBAL.metric_name fails (due to missing metric name or something else) , it falls back to using pfs and show queries.
- For explicity user supplied option, it only uses that query and errors out if it fails.

