### PR TITLE
Update github docs to Block domain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,1 +1,1 @@
-See the [Blip Release Notes](https://cashapp.github.io/blip/about/release-notes/) for the changes in each release.
+See the [Blip Release Notes](https://block.github.io/blip/about/release-notes/) for the changes in each release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ At minimum, all code contributions must meet these criteria:
 
 - [x] Passes all tests
 - [x] Has good code comments
-- [x] Updates the relevant [docs](https://cashapp.github.io/blip/)
+- [x] Updates the relevant [docs](https://block.github.io/blip/)
 - [x] Is formatted with `go fmt`
 - [x] Is idiomatic Go and well designed
 - [x] Follows existing conventions and style

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Blip was created by engineers at [Cash App](https://cash.app) and [Square](https
 
 ## Users
 
-|:book:  [Blip Documentation](https://cashapp.github.io/blip/)|
+|:book:  [Blip Documentation](https://block.github.io/blip/)|
 |---|
 
-:link: [Release Notes](https://cashapp.github.io/blip/release-notes)
+:link: [Release Notes](https://block.github.io/blip/release-notes)
 
 ## Developers
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Checklist
 
 This document outlines how to release a new version of Blip.
-It is not the [release notes](https://cashapp.github.io/blip/release-notes).
+It is not the [release notes](https://block.github.io/blip/about/release-notes).
 
 Review Blip [versioning](https://github.com/cashapp/blip/blob/main/CONTRIBUTING.md#versioning) guidelines.
 
@@ -15,11 +15,11 @@ First, create a branch to prepare the new version.
 
 ## 2. Documentation
 
-Second, update the [documentation](https://cashapp.github.io/blip/).
+Second, update the [documentation](https://block.github.io/blip/).
 Run `docs/serve.sh` to edit locally.
 
-- [ ] Write [release notes](https://cashapp.github.io/blip/release-notes) for the new version (maintain style: past tense one liners)
-- [ ] Check and update [Readiness](https://cashapp.github.io/blip/ready)
+- [ ] Write [release notes](https://block.github.io/blip/about/release-notes) for the new version (maintain style: past tense one liners)
+- [ ] Check and update [Readiness](https://block.github.io/blip/ready)
 - [ ] Update other pages affected by new changes (or ask contributors to update docs affected by their changes)
 - [ ] Glance over all docs to make sure nothing obvious is broken or wrong (including HTML/CSS layout)
 

--- a/blip.go
+++ b/blip.go
@@ -168,7 +168,7 @@ type HTTPClientFactory interface {
 	MakeForSink(sinkName, monitorId string, opts, tags map[string]string) (*http.Client, error)
 }
 
-// Monitor states used for plan changing: https://cashapp.github.io/blip/plans/changing/
+// Monitor states used for plan changing: https://block.github.io/blip/plans/changing/
 const (
 	STATE_NONE      = ""
 	STATE_OFFLINE   = "offline"

--- a/collector.go
+++ b/collector.go
@@ -135,5 +135,5 @@ type CollectorFactory interface {
 	Make(domain string, args CollectorFactoryArgs) (Collector, error)
 }
 
-// ErrMore signals that a collector will return more values. See https://cashapp.github.io/blip/develop/collectors/#long-running.
+// ErrMore signals that a collector will return more values. See https://block.github.io/blip/develop/collectors/#long-running.
 var ErrMore = errors.New("more metrics")

--- a/docs/content/about/release-notes.md
+++ b/docs/content/about/release-notes.md
@@ -48,7 +48,7 @@ func(metrics []*blip.Metrics) error {
   * Removed parallel level collection; made level collection serial
   * Fixed long-running domain handling
   * Added collector max runtime (CMR) context _per domain_ equal to minimum level frequency
-  * Added [`ErrMore`](https://cashapp.github.io/blip/develop/collectors/#long-running)
+  * Added [`ErrMore`](https://block.github.io/blip/develop/collectors/#long-running)
   * Added collector fault fencing: collector and its results are fenced off (dropped) if non-responsive or returns too late
   * Added domain priority: collectors are started by ascending domain frequency (e.g. 5s domain collectors start before 20s domain collectors)
 * Added `blip.Metrics.Interval` field

--- a/examples/copy-meta/README.md
+++ b/examples/copy-meta/README.md
@@ -59,5 +59,3 @@ The `source` meta value for each domain is different:
 These two are difference because of the multi-level replication topology: 02 is the immediate source of 03, but 01 is the heartbeat source.
 
 **This plugin sets `repl.lag` `source` meta value to the immediate source: 02.**
-
-See [Integrate > Plugins](https://cashapp.github.io/blip/v1.0/integrate#plugins) to learn how to use plugins.

--- a/examples/integrate/README.md
+++ b/examples/integrate/README.md
@@ -1,6 +1,6 @@
 # Blip Example: Using Integrations
 
-This example demonstrates using several different [integrations](https://cashapp.github.io/blip/v1.0/integrate) to customize Blip:
+This example demonstrates using several different to customize Blip:
 
 * Register custom metrics collector
 * Set a custom plugin

--- a/monitor/level_collector.go
+++ b/monitor/level_collector.go
@@ -26,7 +26,7 @@ import (
 // looks roughly like: LCO -> Engine -> metric collectors -> MySQL.
 // In Run, the LCO checks every 1s for the highest level in the plan to collect.
 // For example, after 5s it'll collect levels with a frequency divisible by 5s.
-// See https://cashapp.github.io/blip/v1.0/intro/plans.
+// See https://block.github.io/blip/plans/file/.
 //
 // Metrics from MySQL flow back to the LCO as blip.Metrics, which the LCO
 // passes to blip.Plugin.TransformMetrics if specified, then to all sinks

--- a/plan/loader.go
+++ b/plan/loader.go
@@ -236,7 +236,7 @@ func (pl *Loader) Plan(monitorId string, planName string, db *sql.DB) (blip.Plan
 
 	// Point plans to either the monitor plans or shared plans. Monitors plans
 	// take precedence if set; else fall back to shared plans. Related docs:
-	// https://cashapp.github.io/blip/v1.0/plans/loading
+	// https://block.github.io/blip/plans/loading/
 	//
 	// DO NOT MODIFY plans, else you'll modify the underlying slice because Go
 	// slices are refs.


### PR DESCRIPTION
The repo was moved from the CashApp Github Org. This PR fixes doc links by updating them to the new Block domain.