### PR TITLE
Add PostgreSQL module foundations

### DIFF
--- a/blip.go
+++ b/blip.go
@@ -173,7 +173,7 @@ type Plugins struct {
 	// ModifyDB modifies the *sql.DB connection pool. Use with caution.
 	ModifyDB func(*sql.DB, string)
 
-	// ParsePasswordSecret maps an AWS Secrets Manager payload to MySQL credentials.
+	// ParsePasswordSecret maps an AWS Secrets Manager payload to database credentials.
 	// If nil, Blip uses DefaultPasswordSecretParser.
 	ParsePasswordSecret PasswordSecretParser
 

--- a/config.go
+++ b/config.go
@@ -399,6 +399,9 @@ func (c *ConfigMonitorLoader) ApplyDefaults(b Config) {
 
 type ConfigMonitor struct {
 	MonitorId string `yaml:"id"`
+	// DatabaseType selects the database-specific connection and metric module.
+	// Empty values retain Blip's historical MySQL behavior.
+	DatabaseType DatabaseType `yaml:"database-type,omitempty"`
 
 	// ConfigMySQL:
 	Socket         string `yaml:"socket,omitempty"`
@@ -419,6 +422,7 @@ type ConfigMonitor struct {
 	Heartbeat ConfigHeartbeat        `yaml:"heartbeat,omitempty"`
 	Plans     ConfigPlans            `yaml:"plans,omitempty"`
 	Plan      string                 `yaml:"plan,omitempty"`
+	Postgres  ConfigPostgres         `yaml:"postgres,omitempty"`
 	Sinks     ConfigSinks            `yaml:"sinks,omitempty"`
 	TLS       ConfigTLS              `yaml:"tls,omitempty"`
 
@@ -428,6 +432,13 @@ type ConfigMonitor struct {
 const (
 	DEFAULT_MONITOR_USERNAME        = "blip"
 	DEFAULT_MONITOR_TIMEOUT_CONNECT = "10s"
+)
+
+type DatabaseType string
+
+const (
+	DatabaseTypeMySQL    DatabaseType = "mysql"
+	DatabaseTypePostgres DatabaseType = "postgres"
 )
 
 func DefaultConfigMonitor() ConfigMonitor {
@@ -447,7 +458,35 @@ func DefaultConfigMonitor() ConfigMonitor {
 	}
 }
 
+// EffectiveDatabaseType returns the configured database type. An omitted
+// value retains Blip's historical MySQL behavior. Environment interpolation is
+// resolved here because monitor defaults are applied before the normal
+// interpolation pass.
+func (c ConfigMonitor) EffectiveDatabaseType() DatabaseType {
+	databaseType := DatabaseType(interpolateEnv(string(c.DatabaseType)))
+	if databaseType == "" {
+		return DatabaseTypeMySQL
+	}
+	return databaseType
+}
+
 func (c ConfigMonitor) Validate() error {
+	switch c.EffectiveDatabaseType() {
+	case DatabaseTypeMySQL:
+		if c.Postgres.Set() {
+			return fmt.Errorf("config.monitor.postgres requires database-type %q", DatabaseTypePostgres)
+		}
+	case DatabaseTypePostgres:
+		if c.Socket != "" {
+			return fmt.Errorf("config.monitor.socket is only supported for database-type %q", DatabaseTypeMySQL)
+		}
+		if c.MyCnf != "" {
+			return fmt.Errorf("config.monitor.mycnf is only supported for database-type %q", DatabaseTypeMySQL)
+		}
+		return c.Postgres.Validate()
+	default:
+		return fmt.Errorf("config.monitor.database-type: invalid database type %q", c.DatabaseType)
+	}
 	return nil
 }
 
@@ -464,23 +503,32 @@ func (c ConfigMonitor) redacted(seen map[*ConfigMonitor]*ConfigMonitor) ConfigMo
 }
 
 func (c *ConfigMonitor) ApplyDefaults(b Config) {
-	if c.Socket == "" {
-		c.Socket = b.MySQL.Socket
-	}
-	if c.Hostname == "" {
-		c.Hostname = b.MySQL.Hostname
-	}
-	if c.MyCnf == "" && b.MySQL.MyCnf != "" {
-		c.MyCnf = b.MySQL.MyCnf
-	}
-	if c.Username == "" && b.MySQL.Username != "" {
-		c.Username = b.MySQL.Username
-	}
-	if c.Password == "" && b.MySQL.Password != "" {
-		c.Password = b.MySQL.Password
-	}
-	if c.TimeoutConnect == "" && b.MySQL.TimeoutConnect != "" {
-		c.TimeoutConnect = b.MySQL.TimeoutConnect
+	if c.EffectiveDatabaseType() == DatabaseTypeMySQL {
+		if c.Socket == "" {
+			c.Socket = b.MySQL.Socket
+		}
+		if c.Hostname == "" {
+			c.Hostname = b.MySQL.Hostname
+		}
+		if c.MyCnf == "" && b.MySQL.MyCnf != "" {
+			c.MyCnf = b.MySQL.MyCnf
+		}
+		if c.Username == "" && b.MySQL.Username != "" {
+			c.Username = b.MySQL.Username
+		}
+		if c.Password == "" && b.MySQL.Password != "" {
+			c.Password = b.MySQL.Password
+		}
+		if c.TimeoutConnect == "" && b.MySQL.TimeoutConnect != "" {
+			c.TimeoutConnect = b.MySQL.TimeoutConnect
+		}
+	} else {
+		if c.Username == "" {
+			c.Username = DEFAULT_MONITOR_USERNAME
+		}
+		if c.TimeoutConnect == "" {
+			c.TimeoutConnect = DEFAULT_MONITOR_TIMEOUT_CONNECT
+		}
 	}
 	if len(b.Tags) > 0 {
 		if c.Tags == nil {
@@ -501,12 +549,18 @@ func (c *ConfigMonitor) ApplyDefaults(b Config) {
 	c.HA.ApplyDefaults(b)
 	c.Heartbeat.ApplyDefaults(b)
 	c.Plans.ApplyDefaults(b)
+	if c.EffectiveDatabaseType() == DatabaseTypePostgres {
+		postgresDefaults := DefaultConfigPostgres()
+		postgresDefaults.ConnectTimeout = c.TimeoutConnect
+		c.Postgres.ApplyDefaults(postgresDefaults)
+	}
 	c.Sinks.ApplyDefaults(b)
 	c.TLS.ApplyDefaults(b)
 }
 
 func (c *ConfigMonitor) InterpolateEnvVars() {
 	c.MonitorId = interpolateEnv(c.MonitorId)
+	c.DatabaseType = DatabaseType(interpolateEnv(string(c.DatabaseType)))
 	c.MyCnf = interpolateEnv(c.MyCnf)
 	c.Socket = interpolateEnv(c.Socket)
 	c.Hostname = interpolateEnv(c.Hostname)
@@ -526,6 +580,7 @@ func (c *ConfigMonitor) InterpolateEnvVars() {
 	c.Heartbeat.InterpolateEnvVars()
 	c.Plans.InterpolateEnvVars()
 	c.Plan = interpolateEnv(c.Plan)
+	c.Postgres.InterpolateEnvVars()
 	c.Sinks.InterpolateEnvVars()
 	c.TLS.InterpolateEnvVars()
 }
@@ -551,6 +606,7 @@ func (c *ConfigMonitor) InterpolateMonitor() {
 	c.Heartbeat.InterpolateMonitor(c)
 	c.Plans.InterpolateMonitor(c)
 	c.Plan = c.interpolateMon(c.Plan)
+	c.Postgres.InterpolateMonitor(c)
 	c.Sinks.InterpolateMonitor(c)
 	c.TLS.InterpolateMonitor(c)
 }
@@ -586,6 +642,8 @@ func (c *ConfigMonitor) fieldValue(f string) string {
 	switch strings.ToLower(f) {
 	case "monitorid", "monitor-id", "id":
 		return c.MonitorId
+	case "database-type":
+		return string(c.DatabaseType)
 	case "mycnf":
 		return c.MyCnf
 	case "socket":
@@ -600,6 +658,20 @@ func (c *ConfigMonitor) fieldValue(f string) string {
 		return c.PasswordFile
 	case "timeout-connect":
 		return c.TimeoutConnect
+	case "postgres.database":
+		return c.Postgres.Database
+	case "postgres.application-name":
+		return c.Postgres.ApplicationName
+	case "postgres.ssl-mode":
+		return c.Postgres.SSLMode
+	case "postgres.connect-timeout":
+		return c.Postgres.ConnectTimeout
+	case "postgres.statement-timeout":
+		return c.Postgres.StatementTimeout
+	case "postgres.lock-timeout":
+		return c.Postgres.LockTimeout
+	case "postgres.dial-address":
+		return c.Postgres.DialAddress
 	default:
 		return ""
 	}

--- a/config_postgres.go
+++ b/config_postgres.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Block, Inc.
+
+package blip
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DEFAULT_POSTGRES_DATABASE                 = "postgres"
+	DEFAULT_POSTGRES_APPLICATION_NAME         = "pgblip"
+	DEFAULT_POSTGRES_MAX_OPEN_CONNECTIONS     = 4
+	DEFAULT_POSTGRES_MAX_IDLE_CONNECTIONS     = 2
+	DEFAULT_POSTGRES_MAX_CONNECTION_IDLE_TIME = "30s"
+	DEFAULT_POSTGRES_MAX_CONNECTION_LIFETIME  = "0"
+)
+
+// ConfigPostgres configures the PostgreSQL database/sql pool owned by one
+// monitor. Credentials and TLS certificate files remain in the existing
+// monitor-level fields so all Blip credential sources can be shared by
+// database-specific connection factories.
+type ConfigPostgres struct {
+	Database              string `yaml:"database,omitempty"`
+	ApplicationName       string `yaml:"application-name,omitempty"`
+	SSLMode               string `yaml:"ssl-mode,omitempty"`
+	MaxOpenConnections    *int   `yaml:"max-open-connections,omitempty"`
+	MaxIdleConnections    *int   `yaml:"max-idle-connections,omitempty"`
+	MaxConnectionIdleTime string `yaml:"max-connection-idle-time,omitempty"`
+	MaxConnectionLifetime string `yaml:"max-connection-lifetime,omitempty"`
+	ConnectTimeout        string `yaml:"connect-timeout,omitempty"`
+	StatementTimeout      string `yaml:"statement-timeout,omitempty"`
+	LockTimeout           string `yaml:"lock-timeout,omitempty"`
+	DialAddress           string `yaml:"dial-address,omitempty"`
+}
+
+func DefaultConfigPostgres() ConfigPostgres {
+	return ConfigPostgres{
+		Database:              DEFAULT_POSTGRES_DATABASE,
+		ApplicationName:       DEFAULT_POSTGRES_APPLICATION_NAME,
+		MaxOpenConnections:    postgresInt(DEFAULT_POSTGRES_MAX_OPEN_CONNECTIONS),
+		MaxIdleConnections:    postgresInt(DEFAULT_POSTGRES_MAX_IDLE_CONNECTIONS),
+		MaxConnectionIdleTime: DEFAULT_POSTGRES_MAX_CONNECTION_IDLE_TIME,
+		MaxConnectionLifetime: DEFAULT_POSTGRES_MAX_CONNECTION_LIFETIME,
+		ConnectTimeout:        DEFAULT_MONITOR_TIMEOUT_CONNECT,
+	}
+}
+
+// Set reports whether a monitor explicitly contains PostgreSQL configuration.
+func (c ConfigPostgres) Set() bool {
+	return c.Database != "" ||
+		c.ApplicationName != "" ||
+		c.SSLMode != "" ||
+		c.MaxOpenConnections != nil ||
+		c.MaxIdleConnections != nil ||
+		c.MaxConnectionIdleTime != "" ||
+		c.MaxConnectionLifetime != "" ||
+		c.ConnectTimeout != "" ||
+		c.StatementTimeout != "" ||
+		c.LockTimeout != "" ||
+		c.DialAddress != ""
+}
+
+func (c *ConfigPostgres) ApplyDefaults(defaults ConfigPostgres) {
+	if c.Database == "" {
+		c.Database = defaults.Database
+	}
+	if c.ApplicationName == "" {
+		c.ApplicationName = defaults.ApplicationName
+	}
+	if c.SSLMode == "" {
+		c.SSLMode = defaults.SSLMode
+	}
+	c.MaxOpenConnections = setPostgresInt(c.MaxOpenConnections, defaults.MaxOpenConnections)
+	c.MaxIdleConnections = setPostgresInt(c.MaxIdleConnections, defaults.MaxIdleConnections)
+	if c.MaxConnectionIdleTime == "" {
+		c.MaxConnectionIdleTime = defaults.MaxConnectionIdleTime
+	}
+	if c.MaxConnectionLifetime == "" {
+		c.MaxConnectionLifetime = defaults.MaxConnectionLifetime
+	}
+	if c.ConnectTimeout == "" {
+		c.ConnectTimeout = defaults.ConnectTimeout
+	}
+	if c.StatementTimeout == "" {
+		c.StatementTimeout = defaults.StatementTimeout
+	}
+	if c.LockTimeout == "" {
+		c.LockTimeout = defaults.LockTimeout
+	}
+	if c.DialAddress == "" {
+		c.DialAddress = defaults.DialAddress
+	}
+}
+
+func (c ConfigPostgres) Validate() error {
+	validSSLModes := map[string]bool{
+		"":            true,
+		"disable":     true,
+		"allow":       true,
+		"prefer":      true,
+		"require":     true,
+		"verify-ca":   true,
+		"verify-full": true,
+	}
+	if !validSSLModes[strings.ToLower(c.SSLMode)] {
+		return fmt.Errorf("config.postgres.ssl-mode: invalid PostgreSQL SSL mode %q", c.SSLMode)
+	}
+	if c.MaxOpenConnections != nil && *c.MaxOpenConnections < 0 {
+		return fmt.Errorf("config.postgres.max-open-connections: must be greater than or equal to zero")
+	}
+	if c.MaxIdleConnections != nil && *c.MaxIdleConnections < 0 {
+		return fmt.Errorf("config.postgres.max-idle-connections: must be greater than or equal to zero")
+	}
+	if c.MaxOpenConnections != nil && c.MaxIdleConnections != nil &&
+		*c.MaxOpenConnections > 0 && *c.MaxIdleConnections > *c.MaxOpenConnections {
+		return fmt.Errorf("config.postgres.max-idle-connections: cannot exceed max-open-connections")
+	}
+	if err := validatePostgresDuration("connect-timeout", c.ConnectTimeout, false); err != nil {
+		return err
+	}
+	if err := validatePostgresDuration("max-connection-idle-time", c.MaxConnectionIdleTime, true); err != nil {
+		return err
+	}
+	if err := validatePostgresDuration("max-connection-lifetime", c.MaxConnectionLifetime, true); err != nil {
+		return err
+	}
+	if err := validatePostgresDuration("statement-timeout", c.StatementTimeout, true); err != nil {
+		return err
+	}
+	return validatePostgresDuration("lock-timeout", c.LockTimeout, true)
+}
+
+func postgresInt(value int) *int {
+	return &value
+}
+
+func setPostgresInt(value, defaultValue *int) *int {
+	if value != nil || defaultValue == nil {
+		return value
+	}
+	copy := *defaultValue
+	return &copy
+}
+
+func validatePostgresDuration(name, value string, allowZero bool) error {
+	if value == "" {
+		return nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("config.postgres.%s: invalid duration %q: %w", name, value, err)
+	}
+	if duration < 0 || (!allowZero && duration == 0) {
+		constraint := "greater than zero"
+		if allowZero {
+			constraint = "greater than or equal to zero"
+		}
+		return fmt.Errorf("config.postgres.%s: must be %s", name, constraint)
+	}
+	return nil
+}
+
+func (c *ConfigPostgres) InterpolateEnvVars() {
+	c.Database = interpolateEnv(c.Database)
+	c.ApplicationName = interpolateEnv(c.ApplicationName)
+	c.SSLMode = interpolateEnv(c.SSLMode)
+	c.MaxConnectionIdleTime = interpolateEnv(c.MaxConnectionIdleTime)
+	c.MaxConnectionLifetime = interpolateEnv(c.MaxConnectionLifetime)
+	c.ConnectTimeout = interpolateEnv(c.ConnectTimeout)
+	c.StatementTimeout = interpolateEnv(c.StatementTimeout)
+	c.LockTimeout = interpolateEnv(c.LockTimeout)
+	c.DialAddress = interpolateEnv(c.DialAddress)
+}
+
+func (c *ConfigPostgres) InterpolateMonitor(m *ConfigMonitor) {
+	c.Database = m.interpolateMon(c.Database)
+	c.ApplicationName = m.interpolateMon(c.ApplicationName)
+	c.SSLMode = m.interpolateMon(c.SSLMode)
+	c.MaxConnectionIdleTime = m.interpolateMon(c.MaxConnectionIdleTime)
+	c.MaxConnectionLifetime = m.interpolateMon(c.MaxConnectionLifetime)
+	c.ConnectTimeout = m.interpolateMon(c.ConnectTimeout)
+	c.StatementTimeout = m.interpolateMon(c.StatementTimeout)
+	c.LockTimeout = m.interpolateMon(c.LockTimeout)
+	c.DialAddress = m.interpolateMon(c.DialAddress)
+}

--- a/config_postgres_test.go
+++ b/config_postgres_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Block, Inc.
+
+package blip_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cashapp/blip"
+)
+
+func TestConfigMonitorDatabaseTypeDefaultsToMySQLWithoutMutation(t *testing.T) {
+	monitor := blip.ConfigMonitor{}
+	monitor.ApplyDefaults(blip.DefaultConfig())
+
+	if monitor.DatabaseType != "" {
+		t.Fatalf("omitted database type mutated to %q", monitor.DatabaseType)
+	}
+	if monitor.EffectiveDatabaseType() != blip.DatabaseTypeMySQL {
+		t.Fatalf("effective database type = %q, expected mysql", monitor.EffectiveDatabaseType())
+	}
+	if monitor.Postgres.Set() {
+		t.Fatalf("PostgreSQL defaults added to MySQL monitor: %+v", monitor.Postgres)
+	}
+}
+
+func TestConfigMonitorPostgresDefaultsAndInterpolation(t *testing.T) {
+	t.Setenv("BLIP_TEST_DATABASE_TYPE", "postgres")
+	t.Setenv("BLIP_TEST_POSTGRES_DATABASE", "metrics_database")
+	t.Setenv("BLIP_TEST_POSTGRES_DIAL_ADDRESS", "127.0.0.1:35432")
+
+	monitor := blip.ConfigMonitor{
+		MonitorId:      "postgres-monitor",
+		DatabaseType:   "${BLIP_TEST_DATABASE_TYPE}",
+		TimeoutConnect: "7s",
+		Postgres: blip.ConfigPostgres{
+			Database:        "${BLIP_TEST_POSTGRES_DATABASE}",
+			ApplicationName: "%{monitor.id}",
+			DialAddress:     "${BLIP_TEST_POSTGRES_DIAL_ADDRESS}",
+		},
+	}
+	monitor.ApplyDefaults(blip.DefaultConfig())
+	monitor.InterpolateEnvVars()
+	monitor.InterpolateMonitor()
+
+	if err := monitor.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if monitor.DatabaseType != blip.DatabaseTypePostgres {
+		t.Fatalf("database type = %q, expected postgres", monitor.DatabaseType)
+	}
+	if monitor.Postgres.Database != "metrics_database" {
+		t.Fatalf("database = %q, expected metrics_database", monitor.Postgres.Database)
+	}
+	if monitor.Postgres.ApplicationName != monitor.MonitorId {
+		t.Fatalf("application name = %q, expected monitor ID %q", monitor.Postgres.ApplicationName, monitor.MonitorId)
+	}
+	if monitor.Postgres.DialAddress != "127.0.0.1:35432" {
+		t.Fatalf("dial address = %q, expected interpolated address", monitor.Postgres.DialAddress)
+	}
+	if monitor.Postgres.ConnectTimeout != "7s" {
+		t.Fatalf("connect timeout = %q, expected inherited monitor timeout", monitor.Postgres.ConnectTimeout)
+	}
+	if monitor.Postgres.MaxOpenConnections == nil || *monitor.Postgres.MaxOpenConnections != blip.DEFAULT_POSTGRES_MAX_OPEN_CONNECTIONS {
+		t.Fatalf("max open connections not defaulted: %+v", monitor.Postgres.MaxOpenConnections)
+	}
+	if monitor.Postgres.MaxIdleConnections == nil || *monitor.Postgres.MaxIdleConnections != blip.DEFAULT_POSTGRES_MAX_IDLE_CONNECTIONS {
+		t.Fatalf("max idle connections not defaulted: %+v", monitor.Postgres.MaxIdleConnections)
+	}
+}
+
+func TestConfigMonitorDatabaseTypeValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		monitor   blip.ConfigMonitor
+		wantError string
+	}{
+		{
+			name:      "unknown database type",
+			monitor:   blip.ConfigMonitor{DatabaseType: "oracle"},
+			wantError: "invalid database type",
+		},
+		{
+			name: "PostgreSQL config on implicit MySQL monitor",
+			monitor: blip.ConfigMonitor{
+				Postgres: blip.ConfigPostgres{Database: "postgres"},
+			},
+			wantError: "requires database-type",
+		},
+		{
+			name: "my.cnf on PostgreSQL monitor",
+			monitor: blip.ConfigMonitor{
+				DatabaseType: blip.DatabaseTypePostgres,
+				MyCnf:        "/etc/blip/my.cnf",
+			},
+			wantError: "mycnf is only supported",
+		},
+		{
+			name: "socket on PostgreSQL monitor",
+			monitor: blip.ConfigMonitor{
+				DatabaseType: blip.DatabaseTypePostgres,
+				Socket:       "/tmp/.s.PGSQL.5432",
+			},
+			wantError: "socket is only supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.monitor.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("got error %v, expected it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestConfigPostgresAllowsExplicitUnlimitedPoolSettings(t *testing.T) {
+	zero := 0
+	config := blip.ConfigPostgres{
+		Database:           "postgres",
+		MaxOpenConnections: &zero,
+		MaxIdleConnections: &zero,
+	}
+	config.ApplyDefaults(blip.DefaultConfigPostgres())
+
+	if *config.MaxOpenConnections != 0 || *config.MaxIdleConnections != 0 {
+		t.Fatalf("explicit zero pool settings were overwritten: %+v", config)
+	}
+}
+
+func TestConfigPostgresValidation(t *testing.T) {
+	minusOne := -1
+	one := 1
+	two := 2
+	tests := []struct {
+		name      string
+		config    blip.ConfigPostgres
+		wantError string
+	}{
+		{
+			name:      "invalid SSL mode",
+			config:    blip.ConfigPostgres{SSLMode: "invalid"},
+			wantError: "ssl-mode",
+		},
+		{
+			name:      "negative max open",
+			config:    blip.ConfigPostgres{MaxOpenConnections: &minusOne},
+			wantError: "max-open-connections",
+		},
+		{
+			name: "idle exceeds open",
+			config: blip.ConfigPostgres{
+				MaxOpenConnections: &one,
+				MaxIdleConnections: &two,
+			},
+			wantError: "cannot exceed",
+		},
+		{
+			name:      "zero connect timeout",
+			config:    blip.ConfigPostgres{ConnectTimeout: "0"},
+			wantError: "connect-timeout",
+		},
+		{
+			name:      "invalid lifetime",
+			config:    blip.ConfigPostgres{MaxConnectionLifetime: "tomorrow"},
+			wantError: "max-connection-lifetime",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("got error %v, expected it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Block, Inc.
+
+// Package credentials constructs engine-neutral database credential callbacks.
+// Database connection packages remain responsible for engine-specific sources,
+// caching, authentication-error detection, and connection retry behavior.
+package credentials
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cashapp/blip"
+	blipaws "github.com/cashapp/blip/aws"
+)
+
+// Func returns the database credentials currently available from a configured
+// source. Callers decide when to cache or refresh the result.
+type Func func(context.Context) (blip.DbCredentials, error)
+
+// Factory constructs callbacks for credential sources shared by database
+// engines. A nil password-secret parser selects Blip's default RDS secret
+// parser.
+type Factory struct {
+	awsConfig            blip.AWSConfigFactory
+	passwordSecretParser blip.PasswordSecretParser
+}
+
+func NewFactory(awsConfig blip.AWSConfigFactory, passwordSecretParser blip.PasswordSecretParser) Factory {
+	return Factory{
+		awsConfig:            awsConfig,
+		passwordSecretParser: passwordSecretParser,
+	}
+}
+
+// Dynamic returns the first configured shared reloadable source in Blip's
+// established precedence order: IAM, Secrets Manager, then password file. The
+// boolean reports whether a source was selected. Engine-specific factories can
+// insert their own sources before falling back to Static.
+func (f Factory) Dynamic(cfg blip.ConfigMonitor) (Func, bool, error) {
+	if blip.True(cfg.AWS.IAMAuth) {
+		blip.Debug("%s: AWS IAM auth token password", cfg.MonitorId)
+		if f.awsConfig == nil {
+			return nil, true, fmt.Errorf("AWS IAM authentication requires an AWS config factory")
+		}
+		awscfg, err := f.awsConfig.Make(blip.AWS{Region: cfg.AWS.Region}, cfg.Hostname)
+		if err != nil {
+			return nil, true, err
+		}
+		token := blipaws.NewAuthToken(cfg.Username, cfg.Hostname, awscfg)
+		return func(ctx context.Context) (blip.DbCredentials, error) {
+			password, err := token.Password(ctx)
+			if err != nil {
+				return blip.DbCredentials{}, err
+			}
+			return blip.DbCredentials{Username: cfg.Username, Password: password}, nil
+		}, true, nil
+	}
+
+	if cfg.AWS.PasswordSecret != "" {
+		blip.Debug("%s: AWS Secrets Manager password", cfg.MonitorId)
+		if f.awsConfig == nil {
+			return nil, true, fmt.Errorf("AWS Secrets Manager credentials require an AWS config factory")
+		}
+		awscfg, err := f.awsConfig.Make(blip.AWS{Region: cfg.AWS.Region}, cfg.Hostname)
+		if err != nil {
+			return nil, true, err
+		}
+		secret := blipaws.NewSecret(cfg.AWS.PasswordSecret, awscfg)
+		parser := f.passwordSecretParser
+		if parser == nil {
+			parser = blip.DefaultPasswordSecretParser
+		}
+		return func(ctx context.Context) (blip.DbCredentials, error) {
+			payload, err := secret.GetSecretPayload(ctx)
+			if err != nil {
+				return blip.DbCredentials{}, err
+			}
+			credentials := blip.DbCredentials{Username: cfg.Username}
+			if err := parser(ctx, cfg, payload, &credentials); err != nil {
+				return blip.DbCredentials{}, err
+			}
+			return credentials, nil
+		}, true, nil
+	}
+
+	if cfg.PasswordFile != "" {
+		blip.Debug("%s: password file", cfg.MonitorId)
+		return func(context.Context) (blip.DbCredentials, error) {
+			contents, err := os.ReadFile(cfg.PasswordFile)
+			if err != nil {
+				return blip.DbCredentials{}, err
+			}
+			return blip.DbCredentials{Username: cfg.Username, Password: string(contents)}, nil
+		}, true, nil
+	}
+
+	return nil, false, nil
+}
+
+// Static returns a callback for the configured static username and password.
+// It also represents passwordless authentication when Password is empty.
+func Static(cfg blip.ConfigMonitor) Func {
+	if cfg.Password == "" {
+		blip.Debug("%s: no password", cfg.MonitorId)
+	} else {
+		blip.Debug("%s: static password credentials", cfg.MonitorId)
+	}
+	return func(context.Context) (blip.DbCredentials, error) {
+		return blip.DbCredentials{Username: cfg.Username, Password: cfg.Password}, nil
+	}
+}

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Block, Inc.
+
+package credentials_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/credentials"
+)
+
+func TestDynamicPasswordFileReloads(t *testing.T) {
+	passwordFile := filepath.Join(t.TempDir(), "password")
+	if err := os.WriteFile(passwordFile, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	credentialFunc, selected, err := credentials.NewFactory(nil, nil).Dynamic(blip.ConfigMonitor{
+		Username:     "metrics",
+		PasswordFile: passwordFile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !selected {
+		t.Fatal("password file was not selected")
+	}
+	first, err := credentialFunc(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Username != "metrics" || first.Password != "first" {
+		t.Fatalf("first credentials = %+v", first)
+	}
+
+	if err := os.WriteFile(passwordFile, []byte("second"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := credentialFunc(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Username != "metrics" || second.Password != "second" {
+		t.Fatalf("reloaded credentials = %+v", second)
+	}
+}
+
+func TestDynamicPreservesSourcePrecedence(t *testing.T) {
+	iamAuth := true
+	tests := []struct {
+		name      string
+		config    blip.ConfigMonitor
+		wantError string
+	}{
+		{
+			name: "IAM before secret and file",
+			config: blip.ConfigMonitor{
+				PasswordFile: "/unused",
+				AWS: blip.ConfigAWS{
+					IAMAuth:        &iamAuth,
+					PasswordSecret: "unused",
+				},
+			},
+			wantError: "IAM authentication",
+		},
+		{
+			name: "secret before file",
+			config: blip.ConfigMonitor{
+				PasswordFile: "/unused",
+				AWS:          blip.ConfigAWS{PasswordSecret: "unused"},
+			},
+			wantError: "Secrets Manager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credentialFunc, selected, err := credentials.NewFactory(nil, nil).Dynamic(tt.config)
+			if !selected {
+				t.Fatal("configured source was not selected")
+			}
+			if credentialFunc != nil {
+				t.Fatal("credential callback returned despite missing AWS factory")
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("got error %v, expected it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestDynamicReportsNoSharedSource(t *testing.T) {
+	credentialFunc, selected, err := credentials.NewFactory(nil, nil).Dynamic(blip.ConfigMonitor{
+		Username: "metrics",
+		Password: "static",
+	})
+	if err != nil || selected || credentialFunc != nil {
+		t.Fatalf("Dynamic returned func=%v selected=%t err=%v", credentialFunc != nil, selected, err)
+	}
+}
+
+func TestStatic(t *testing.T) {
+	credentialFunc := credentials.Static(blip.ConfigMonitor{Username: "metrics", Password: "static"})
+	got, err := credentialFunc(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "metrics" || got.Password != "static" {
+		t.Fatalf("credentials = %+v", got)
+	}
+}

--- a/dbconn/credentials_test.go
+++ b/dbconn/credentials_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Block, Inc.
+
+package dbconn_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/dbconn"
+)
+
+func TestCredentialsPreserveMySQLMyCnfPrecedence(t *testing.T) {
+	factory := dbconn.NewConnFactory(nil, nil)
+	credentialFunc, err := factory.Credentials(blip.ConfigMonitor{
+		Username: "static-user",
+		Password: "static-password",
+		MyCnf:    "../test/mycnf/full-dsn",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := credentialFunc(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "U" || got.Password != "P" {
+		t.Fatalf("credentials = %+v, expected my.cnf credentials", got)
+	}
+}
+
+func TestCredentialsPreservePasswordFileBeforeMyCnf(t *testing.T) {
+	passwordFile := filepath.Join(t.TempDir(), "password")
+	if err := os.WriteFile(passwordFile, []byte("file-password"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	factory := dbconn.NewConnFactory(nil, nil)
+	credentialFunc, err := factory.Credentials(blip.ConfigMonitor{
+		Username:     "file-user",
+		PasswordFile: passwordFile,
+		MyCnf:        "../test/mycnf/full-dsn",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := credentialFunc(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "file-user" || got.Password != "file-password" {
+		t.Fatalf("credentials = %+v, expected password-file credentials", got)
+	}
+}

--- a/dbconn/factory.go
+++ b/dbconn/factory.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cashapp/blip"
 	"github.com/cashapp/blip/aws"
+	"github.com/cashapp/blip/credentials"
 )
 
 // rdsAddr matches Amazon RDS hostnames with optional :port suffix.
@@ -274,46 +275,9 @@ func (f factory) Make(cfg blip.ConfigMonitor) (*sql.DB, string, error) {
 // credentials are fetched via a reload func, even a static credential specified
 // in the Blip config file.
 func (f factory) Credentials(cfg blip.ConfigMonitor) (CredentialFunc, error) {
-
-	// Amazon IAM auth token (valid 15 min)
-	if blip.True(cfg.AWS.IAMAuth) {
-		blip.Debug("%s: AWS IAM auth token password", cfg.MonitorId)
-		awscfg, err := f.awsConfig.Make(blip.AWS{Region: cfg.AWS.Region}, cfg.Hostname)
-		if err != nil {
-			return nil, err
-		}
-		token := aws.NewAuthToken(cfg.Username, cfg.Hostname, awscfg)
-		return func(ctx context.Context) (blip.DbCredentials, error) {
-			passwd, err := token.Password(ctx)
-			if err != nil {
-				return blip.DbCredentials{}, err
-			}
-
-			return blip.DbCredentials{
-				Password: passwd,
-				Username: cfg.Username,
-			}, nil
-		}, nil
-	}
-
-	// Amazon Secrets Manager, could be rotated
-	if cfg.AWS.PasswordSecret != "" {
-		return f.passwordSecretCredentialFunc(cfg)
-	}
-
-	// Password file, could be "rotated" (new password written to file)
-	if cfg.PasswordFile != "" {
-		blip.Debug("%s: password file", cfg.MonitorId)
-		return func(context.Context) (blip.DbCredentials, error) {
-			bytes, err := os.ReadFile(cfg.PasswordFile)
-			if err != nil {
-				return blip.DbCredentials{}, err
-			}
-			return blip.DbCredentials{
-				Password: string(bytes),
-				Username: cfg.Username,
-			}, err
-		}, nil
+	credentialFunc, selected, err := credentials.NewFactory(f.awsConfig, f.passwordSecretParser).Dynamic(cfg)
+	if err != nil || selected {
+		return credentialFunc, err
 	}
 
 	// Credentials in my.cnf file, could be rotated (username and/or password, along with TLS config)
@@ -332,47 +296,7 @@ func (f factory) Credentials(cfg blip.ConfigMonitor) (CredentialFunc, error) {
 		}, nil
 	}
 
-	// Static password in Blip config file, not rotated
-	if cfg.Password != "" {
-		blip.Debug("%s: static password credentials", cfg.MonitorId)
-		return func(context.Context) (blip.DbCredentials, error) {
-			return blip.DbCredentials{Password: cfg.Password, Username: cfg.Username}, nil
-		}, nil
-	}
-
-	blip.Debug("%s: no password", cfg.MonitorId)
-	return func(context.Context) (blip.DbCredentials, error) {
-		return blip.DbCredentials{Password: "", Username: cfg.Username}, nil
-	}, nil
-}
-
-func (f factory) passwordSecretCredentialFunc(cfg blip.ConfigMonitor) (CredentialFunc, error) {
-	blip.Debug("%s: AWS Secrets Manager password", cfg.MonitorId)
-	awscfg, err := f.awsConfig.Make(blip.AWS{Region: cfg.AWS.Region}, cfg.Hostname)
-	if err != nil {
-		return nil, err
-	}
-	secret := aws.NewSecret(cfg.AWS.PasswordSecret, awscfg)
-	parser := f.passwordSecretParser
-	if parser == nil {
-		parser = blip.DefaultPasswordSecretParser
-	}
-
-	return func(ctx context.Context) (blip.DbCredentials, error) {
-		payload, err := secret.GetSecretPayload(ctx)
-		if err != nil {
-			return blip.DbCredentials{}, err
-		}
-
-		credentials := blip.DbCredentials{
-			Username: cfg.Username,
-		}
-		if err := parser(ctx, cfg, payload, &credentials); err != nil {
-			return blip.DbCredentials{}, err
-		}
-
-		return credentials, nil
-	}, nil
+	return credentials.Static(cfg), nil
 }
 
 // --------------------------------------------------------------------------

--- a/dbconn/password_secret_test.go
+++ b/dbconn/password_secret_test.go
@@ -69,7 +69,7 @@ func TestPasswordSecretCredentialFuncDefaultParser(t *testing.T) {
 	defer cleanup()
 
 	f := factory{awsConfig: testAWSConfigFactory{cfg: awscfg}}
-	credentialFunc, err := f.passwordSecretCredentialFunc(blip.ConfigMonitor{
+	credentialFunc, err := f.Credentials(blip.ConfigMonitor{
 		Hostname: "db.example.com",
 		Username: "config-user",
 		AWS: blip.ConfigAWS{
@@ -116,7 +116,7 @@ func TestPasswordSecretCredentialFuncCustomParser(t *testing.T) {
 			return nil
 		},
 	}
-	credentialFunc, err := f.passwordSecretCredentialFunc(blip.ConfigMonitor{
+	credentialFunc, err := f.Credentials(blip.ConfigMonitor{
 		Hostname: "db.example.com",
 		Username: "config-user",
 		AWS: blip.ConfigAWS{
@@ -154,7 +154,7 @@ func TestPasswordSecretCredentialFuncParserError(t *testing.T) {
 			return parseErr
 		},
 	}
-	credentialFunc, err := f.passwordSecretCredentialFunc(blip.ConfigMonitor{
+	credentialFunc, err := f.Credentials(blip.ConfigMonitor{
 		Hostname: "db.example.com",
 		Username: "config-user",
 		AWS: blip.ConfigAWS{
@@ -187,7 +187,7 @@ func TestPasswordSecretCredentialFuncGetSecretError(t *testing.T) {
 			},
 		}},
 	}
-	credentialFunc, err := f.passwordSecretCredentialFunc(blip.ConfigMonitor{
+	credentialFunc, err := f.Credentials(blip.ConfigMonitor{
 		Hostname: "db.example.com",
 		Username: "config-user",
 		AWS: blip.ConfigAWS{
@@ -209,7 +209,7 @@ func TestPasswordSecretCredentialFuncAWSConfigError(t *testing.T) {
 	configErr := errors.New("aws config")
 	f := factory{awsConfig: testAWSConfigFactory{err: configErr}}
 
-	_, err := f.passwordSecretCredentialFunc(blip.ConfigMonitor{
+	_, err := f.Credentials(blip.ConfigMonitor{
 		Hostname: "db.example.com",
 		Username: "config-user",
 		AWS: blip.ConfigAWS{

--- a/dbconn/reload_password.go
+++ b/dbconn/reload_password.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/credentials"
 	"github.com/cashapp/blip/event"
 )
 
@@ -17,7 +18,9 @@ func init() {
 	dsndriver.SetHotswapFunc(Repo.ReloadDSN)
 }
 
-type CredentialFunc func(context.Context) (blip.DbCredentials, error)
+// CredentialFunc is retained as an alias for compatibility with integrations
+// that used the MySQL dbconn package to construct credential callbacks.
+type CredentialFunc = credentials.Func
 
 type repo struct {
 	m *sync.Map


### PR DESCRIPTION
## Why
Allow an external PostgreSQL module to reuse Blip configuration and credential sources without changing existing MySQL monitor behavior.

## What
- Add explicit monitor database typing with omitted values retaining MySQL semantics
- Add typed PostgreSQL monitor and pool configuration
- Extract engine-neutral IAM, Secrets Manager, password-file, and static credential callbacks
- Preserve MySQL my.cnf, TLS reload, and authentication hotswap behavior

## Risk Assessment
Low for this PR because it targets the isolated PostgreSQL-module feature branch. The changes touch core configuration and credentials, but the complete MySQL regression suite passes against MySQL 8.0 and 8.4.

## References
- `go test ./... -count=1` with the repository MySQL fixtures
- `go vet ./...`
- `git diff --check`

Generated with Codex