### PR TITLE
Add database-aware metric collectors

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -22,8 +22,8 @@ type Collector interface {
 	// Prepare prepares a plan for future calls to Collect. The return function
 	// is called once when the collector is destroyed; it allows the collector
 	// to clean up. If Prepare returns an error, Blip will retry preparing the
-	// plan. Therefore, Prepare should not retry on error (for example, if MySQL
-	// is not online yet).
+	// plan. Therefore, Prepare should not retry on error (for example, if the
+	// database is not online yet).
 	Prepare(ctx context.Context, plan Plan) (func(), error)
 
 	// Collect collects metrics for the previously prepared plan. Collect is only
@@ -111,13 +111,14 @@ func (h CollectorHelp) Validate(opts map[string]string) error {
 // a Collector. The factory must use the args to create the collector.
 type CollectorFactoryArgs struct {
 	// Config is the full and final monitor config. Most collectors do not need
-	// this, but some that collect metrics outside MySQL, like cloud metrics,
+	// this, but some that collect metrics outside the database, like cloud metrics,
 	// might need additional monitor config values.
 	Config ConfigMonitor
 
-	// DB is the connection to MySQL. It is safe for concurrent use, and it is
-	// used concurrently by other parts of a monitor. The Collector must not
-	// modify the connection, reconnect, and so forth--only use the connection.
+	// DB is the monitor's database connection. It is safe for concurrent use,
+	// and it is used concurrently by other parts of a monitor. The Collector
+	// must not modify the connection, reconnect, and so forth--only use the
+	// connection.
 	DB *sql.DB
 
 	// MonitorId is the monitor identifier. The Collector must include
@@ -133,6 +134,18 @@ type CollectorFactoryArgs struct {
 // A CollectorFactory makes one or more Collector.
 type CollectorFactory interface {
 	Make(domain string, args CollectorFactoryArgs) (Collector, error)
+}
+
+// CollectorFactoryDatabaseTypes is an optional CollectorFactory capability
+// that identifies the database types supported by a domain. Factories that do
+// not implement this interface retain Blip's historical MySQL behavior.
+//
+// The domain argument allows one factory to serve domains with different
+// compatibility, such as MySQL collectors and database-neutral cloud metrics.
+// Implementations must return at least one database type.
+type CollectorFactoryDatabaseTypes interface {
+	CollectorFactory
+	DatabaseTypes(domain string) []DatabaseType
 }
 
 // ErrMore signals that a collector will return more values. See https://block.github.io/blip/develop/collectors/#long-running.

--- a/docs/content/develop/collectors.md
+++ b/docs/content/develop/collectors.md
@@ -114,7 +114,7 @@ Example [https://github.com/cashapp/blip/tree/main/examples/integrate](https://g
 The high-level work is:
 
 1. Implement `blip.Collector` and `blip.CollectorFactory`
-2. Register the domain/collector by calling `metrics.Register(myFactory, "foo")`
+2. Register the domain/collector by calling `metrics.Register("foo", myFactory)`
 3. Use the domain in a plan:
 
 ```yaml
@@ -123,6 +123,18 @@ level:
     foo: # Custom domain/collector
       metrics:
         - whatever
+```
+
+`metrics.Register` preserves the original integration behavior: a factory that
+only implements `CollectorFactory` is treated as MySQL. A factory for another
+database type implements the optional `CollectorFactoryDatabaseTypes`
+capability so Blip can reject an incompatible monitor plan before collector
+preparation:
+
+```go
+func (myFactory) DatabaseTypes(string) []blip.DatabaseType {
+    return []blip.DatabaseType{blip.DatabaseTypePostgres}
+}
 ```
 
 ## Long-running

--- a/docs/content/plans/file.md
+++ b/docs/content/plans/file.md
@@ -49,6 +49,12 @@ And each domain has a domain-specific configuration that includes:
 
 These values are documented for each [domain]({{< ref "/metrics/domains" >}}) and printed on the command line by [`--print-domains`]({{< ref "/config/blip#--print-domains" >}}).
 
+All domains in a plan, across every level, must support at least one common
+database type. A MySQL-only domain and a domain that supports both MySQL and
+PostgreSQL can share a plan, but a MySQL-only domain and a PostgreSQL-only
+domain cannot. A shared plan configuration can still contain separate plans
+for different database types.
+
 Since Blip automatically levels up overlapping frequencies (described in [Intro / Plans]({{< ref "intro/plans" >}})), it's conventional to define levels from most to least frequent, as in this example:
 
 ```yaml

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -28,23 +28,73 @@ import (
 	waitiotable "github.com/cashapp/blip/metrics/wait.io.table"
 )
 
-// Register registers a factory that makes one or more collector by domain name.
-// This is function is one several integration points because it allows users
+// Register registers a factory that makes one or more collectors by domain name.
+// This is one of several integration points because it allows users
 // to plug in new metric collectors by providing a factory to make them.
 // Blip calls this function in an init function to register the built-in metric
 // collectors.
 //
+// If the factory implements blip.CollectorFactoryDatabaseTypes, Blip records
+// the database types it declares for this domain. Existing factories that do
+// not implement that optional interface retain Blip's historical MySQL
+// behavior.
+//
 // See types in the blip package for more details.
 func Register(domain string, f blip.CollectorFactory) error {
 	r.Lock()
-	defer r.Unlock()
-	_, ok := r.factory[domain]
-	if ok {
+	_, registered := r.factory[domain]
+	r.Unlock()
+	if registered {
 		return fmt.Errorf("%s already registered", domain)
 	}
-	r.factory[domain] = f
-	blip.Debug("register collector %s", domain)
+
+	databaseTypes := []blip.DatabaseType{blip.DatabaseTypeMySQL}
+	if typedFactory, ok := f.(blip.CollectorFactoryDatabaseTypes); ok {
+		databaseTypes = typedFactory.DatabaseTypes(domain)
+	}
+	databaseTypes, err := normalizeDatabaseTypes(domain, databaseTypes)
+	if err != nil {
+		return err
+	}
+
+	r.Lock()
+	defer r.Unlock()
+	// Another goroutine might have registered the domain while the factory's
+	// optional compatibility metadata was being evaluated.
+	if _, registered := r.factory[domain]; registered {
+		return fmt.Errorf("%s already registered", domain)
+	}
+	r.factory[domain] = registeredFactory{
+		factory:       f,
+		databaseTypes: databaseTypes,
+	}
+	blip.Debug("register collector %s for database types %v", domain, databaseTypes)
 	return nil
+}
+
+func normalizeDatabaseTypes(domain string, databaseTypes []blip.DatabaseType) ([]blip.DatabaseType, error) {
+	if len(databaseTypes) == 0 {
+		return nil, fmt.Errorf("collector %s supports no database types", domain)
+	}
+
+	seen := map[blip.DatabaseType]bool{}
+	normalized := make([]blip.DatabaseType, 0, len(databaseTypes))
+	for _, databaseType := range databaseTypes {
+		switch databaseType {
+		case blip.DatabaseTypeMySQL, blip.DatabaseTypePostgres:
+		default:
+			return nil, fmt.Errorf("collector %s declares invalid database type %q", domain, databaseType)
+		}
+		if seen[databaseType] {
+			continue
+		}
+		seen[databaseType] = true
+		normalized = append(normalized, databaseType)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i] < normalized[j]
+	})
+	return normalized, nil
 }
 
 // Remove removes the metrics collector factory for the given domain. This is
@@ -77,18 +127,61 @@ func Exists(domain string) bool {
 	return ok
 }
 
+// SupportedDatabaseTypes returns a copy of the database types supported by the
+// registered collector domain.
+func SupportedDatabaseTypes(domain string) ([]blip.DatabaseType, error) {
+	r.Lock()
+	defer r.Unlock()
+	registered, ok := r.factory[domain]
+	if !ok {
+		return nil, fmt.Errorf("invalid domain: %s (no factory registered)", domain)
+	}
+	databaseTypes := make([]blip.DatabaseType, len(registered.databaseTypes))
+	copy(databaseTypes, registered.databaseTypes)
+	return databaseTypes, nil
+}
+
+// ValidateDatabase returns nil if the domain exists and can be used with the
+// database type.
+func ValidateDatabase(domain string, databaseType blip.DatabaseType) error {
+	r.Lock()
+	defer r.Unlock()
+	return validateDatabase(domain, databaseType)
+}
+
+func validateDatabase(domain string, databaseType blip.DatabaseType) error {
+	registered, ok := r.factory[domain]
+	if !ok {
+		return fmt.Errorf("invalid domain: %s (no factory registered)", domain)
+	}
+	for _, supportedType := range registered.databaseTypes {
+		if supportedType == databaseType {
+			return nil
+		}
+	}
+	return fmt.Errorf("collector %s does not support database type %q (supported: %v)",
+		domain, databaseType, registered.databaseTypes)
+}
+
 // Make makes a metric collector for the domain using a previously registered factory.
 //
 // See types in the blip package for more details.
 func Make(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
 	r.Lock()
 	defer r.Unlock()
-	f, ok := r.factory[domain]
+	registered, ok := r.factory[domain]
 	if !ok {
 		return nil, fmt.Errorf("invalid domain: %s (no factory registered)", domain)
 
 	}
-	return f.Make(domain, args)
+	// ValidatePlans creates collectors without a monitor. Database compatibility
+	// is checked when the monitor resolves the selected plan.
+	if !args.Validate {
+		if err := validateDatabase(domain, args.Config.EffectiveDatabaseType()); err != nil {
+			return nil, err
+		}
+	}
+	return registered.factory.Make(domain, args)
 }
 
 func PrintDomains() string {
@@ -216,14 +309,19 @@ func init() {
 // instance below.
 type repo struct {
 	*sync.Mutex
-	factory map[string]blip.CollectorFactory
+	factory map[string]registeredFactory
+}
+
+type registeredFactory struct {
+	factory       blip.CollectorFactory
+	databaseTypes []blip.DatabaseType
 }
 
 // Internal package instance of repo that holds all collector factories registered
 // by calls to Register, which includes the built-in factories.
 var r = &repo{
 	Mutex:   &sync.Mutex{},
-	factory: map[string]blip.CollectorFactory{},
+	factory: map[string]registeredFactory{},
 }
 
 // factory is the built-in factory for creating all built-in collectors.
@@ -234,6 +332,7 @@ type factory struct {
 }
 
 var _ blip.CollectorFactory = &factory{}
+var _ blip.CollectorFactoryDatabaseTypes = &factory{}
 
 // Internet package instance of factory that makes all built-it collectors.
 // This factory is registered in the init func above.
@@ -242,6 +341,16 @@ var f = &factory{}
 func InitFactory(factories blip.Factories) {
 	f.AWSConfig = factories.AWSConfig
 	f.HTTPClient = factories.HTTPClient
+}
+
+func (f *factory) DatabaseTypes(domain string) []blip.DatabaseType {
+	if domain == awsrds.DOMAIN {
+		return []blip.DatabaseType{
+			blip.DatabaseTypeMySQL,
+			blip.DatabaseTypePostgres,
+		}
+	}
+	return []blip.DatabaseType{blip.DatabaseTypeMySQL}
 }
 
 // Make makes a metric collector for the domain. This is the built-in factory

--- a/metrics/factory_test.go
+++ b/metrics/factory_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Block, Inc.
+
+package metrics_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/metrics"
+	"github.com/cashapp/blip/test/mock"
+)
+
+type databaseTypesFactory struct {
+	mock.MetricFactory
+	databaseTypes func(string) []blip.DatabaseType
+}
+
+func (f databaseTypesFactory) DatabaseTypes(domain string) []blip.DatabaseType {
+	return f.databaseTypes(domain)
+}
+
+func TestRegisterDefaultsToMySQL(t *testing.T) {
+	const domain = "test.legacy-mysql"
+	factory := mock.MetricFactory{}
+
+	if err := metrics.Register(domain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	if err := metrics.ValidateDatabase(domain, blip.DatabaseTypeMySQL); err != nil {
+		t.Fatalf("ValidateDatabase(mysql): %v", err)
+	}
+	if _, err := metrics.Make(domain, blip.CollectorFactoryArgs{}); err != nil {
+		t.Fatalf("Make(default mysql): %v", err)
+	}
+
+	err := metrics.ValidateDatabase(domain, blip.DatabaseTypePostgres)
+	if err == nil || !strings.Contains(err.Error(), `does not support database type "postgres" (supported: [mysql])`) {
+		t.Fatalf("ValidateDatabase(postgres) error = %v", err)
+	}
+}
+
+func TestRegisterUsesFactoryDatabaseTypes(t *testing.T) {
+	const domain = "test.postgres-only"
+	factory := databaseTypesFactory{
+		databaseTypes: func(gotDomain string) []blip.DatabaseType {
+			if gotDomain != domain {
+				t.Fatalf("DatabaseTypes domain = %q, expected %q", gotDomain, domain)
+			}
+			return []blip.DatabaseType{blip.DatabaseTypePostgres}
+		},
+	}
+
+	if err := metrics.Register(domain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	if err := metrics.ValidateDatabase(domain, blip.DatabaseTypePostgres); err != nil {
+		t.Fatalf("ValidateDatabase(postgres): %v", err)
+	}
+	if _, err := metrics.Make(domain, blip.CollectorFactoryArgs{
+		Config: blip.ConfigMonitor{DatabaseType: blip.DatabaseTypePostgres},
+	}); err != nil {
+		t.Fatalf("Make(postgres): %v", err)
+	}
+
+	err := metrics.ValidateDatabase(domain, blip.DatabaseTypeMySQL)
+	if err == nil || !strings.Contains(err.Error(), `does not support database type "mysql" (supported: [postgres])`) {
+		t.Fatalf("ValidateDatabase(mysql) error = %v", err)
+	}
+	if _, err := metrics.Make(domain, blip.CollectorFactoryArgs{}); err == nil {
+		t.Fatal("Make with the default MySQL database type succeeded")
+	}
+
+	// Global plan validation has no monitor database type. It must still be
+	// able to construct the collector so shared plans can be loaded.
+	if _, err := metrics.Make(domain, blip.CollectorFactoryArgs{Validate: true}); err != nil {
+		t.Fatalf("Make(validate): %v", err)
+	}
+}
+
+func TestRegisterSupportsMultipleDatabaseTypes(t *testing.T) {
+	const domain = "test.multiple-database-types"
+	factory := databaseTypesFactory{
+		databaseTypes: func(string) []blip.DatabaseType {
+			return []blip.DatabaseType{
+				blip.DatabaseTypePostgres,
+				blip.DatabaseTypeMySQL,
+				blip.DatabaseTypePostgres,
+			}
+		},
+	}
+
+	if err := metrics.Register(domain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	for _, databaseType := range []blip.DatabaseType{
+		blip.DatabaseTypeMySQL,
+		blip.DatabaseTypePostgres,
+	} {
+		if err := metrics.ValidateDatabase(domain, databaseType); err != nil {
+			t.Fatalf("ValidateDatabase(%s): %v", databaseType, err)
+		}
+	}
+
+	databaseTypes, err := metrics.SupportedDatabaseTypes(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(databaseTypes) != 2 ||
+		databaseTypes[0] != blip.DatabaseTypeMySQL ||
+		databaseTypes[1] != blip.DatabaseTypePostgres {
+		t.Fatalf("SupportedDatabaseTypes = %v", databaseTypes)
+	}
+
+	// The registry owns its normalized compatibility metadata.
+	databaseTypes[0] = "mutated"
+	if err := metrics.ValidateDatabase(domain, blip.DatabaseTypeMySQL); err != nil {
+		t.Fatalf("ValidateDatabase(mysql) after returned slice mutation: %v", err)
+	}
+}
+
+func TestRegisterValidatesFactoryDatabaseTypes(t *testing.T) {
+	tests := map[string]struct {
+		databaseTypes []blip.DatabaseType
+		errorContains string
+	}{
+		"empty": {
+			databaseTypes: nil,
+			errorContains: "supports no database types",
+		},
+		"invalid": {
+			databaseTypes: []blip.DatabaseType{"oracle"},
+			errorContains: `declares invalid database type "oracle"`,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			domain := "test.invalid-database-types-" + name
+			factory := databaseTypesFactory{
+				databaseTypes: func(string) []blip.DatabaseType {
+					return tt.databaseTypes
+				},
+			}
+
+			err := metrics.Register(domain, factory)
+			if err == nil || !strings.Contains(err.Error(), tt.errorContains) {
+				t.Fatalf("Register error = %v", err)
+			}
+			if metrics.Exists(domain) {
+				t.Fatalf("%s was registered", domain)
+			}
+		})
+	}
+}
+
+func TestRegisterDuplicateDoesNotInspectFactoryDatabaseTypes(t *testing.T) {
+	const domain = "test.duplicate-database-types"
+	if err := metrics.Register(domain, mock.MetricFactory{}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	factory := databaseTypesFactory{
+		databaseTypes: func(string) []blip.DatabaseType {
+			t.Fatal("DatabaseTypes called for duplicate registration")
+			return nil
+		},
+	}
+	err := metrics.Register(domain, factory)
+	if err == nil || !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("Register duplicate error = %v", err)
+	}
+}
+
+func TestBuiltInCollectorDatabaseCompatibility(t *testing.T) {
+	if err := metrics.ValidateDatabase("status.global", blip.DatabaseTypeMySQL); err != nil {
+		t.Fatalf("status.global with MySQL: %v", err)
+	}
+	if err := metrics.ValidateDatabase("status.global", blip.DatabaseTypePostgres); err == nil {
+		t.Fatal("status.global supports PostgreSQL")
+	}
+
+	for _, databaseType := range []blip.DatabaseType{
+		blip.DatabaseTypeMySQL,
+		blip.DatabaseTypePostgres,
+	} {
+		if err := metrics.ValidateDatabase("aws.rds", databaseType); err != nil {
+			t.Fatalf("aws.rds with %s: %v", databaseType, err)
+		}
+	}
+}

--- a/plan/loader.go
+++ b/plan/loader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,7 @@ type Loader struct {
 	plugin       func(blip.ConfigPlans) ([]blip.Plan, error)
 	sharedPlans  []Meta            // keyed on Plan.Name
 	monitorPlans map[string][]Meta // keyed on monitorId, Plan.Name
+	monitorTypes map[string]blip.DatabaseType
 	*sync.RWMutex
 }
 
@@ -44,6 +46,7 @@ func NewLoader(plugin func(blip.ConfigPlans) ([]blip.Plan, error)) *Loader {
 		plugin:       plugin,
 		sharedPlans:  []Meta{},
 		monitorPlans: map[string][]Meta{},
+		monitorTypes: map[string]blip.DatabaseType{},
 		RWMutex:      &sync.RWMutex{},
 	}
 }
@@ -173,6 +176,13 @@ func (pl *Loader) LoadShared(cfg blip.ConfigPlans, dbMaker blip.DbFactory) error
 func (pl *Loader) LoadMonitor(mon blip.ConfigMonitor, dbMaker blip.DbFactory) error {
 	event.Sendf(event.PLANS_LOAD_MONITOR, "%s", mon.MonitorId)
 
+	// Remember the type even when the monitor uses only shared plans. Global
+	// plan loading validates domains and options; compatibility is validated
+	// after this monitor selects one of those plans.
+	pl.Lock()
+	pl.monitorTypes[mon.MonitorId] = mon.EffectiveDatabaseType()
+	pl.Unlock()
+
 	if mon.Plans.Table == "" && len(mon.Plans.Files) == 0 {
 		blip.Debug("monitor %s uses only shared plans", mon.MonitorId)
 		return nil
@@ -286,7 +296,16 @@ func (pl *Loader) Plan(monitorId string, planName string, db *sql.DB) (blip.Plan
 	blip.Debug("%s: loading plan %s from %s", monitorId, planName, pm.Source)
 	// Since blip.Plan has field types that pass by reference (maps and slices), we want to the returned plan to
 	// be a deep copy to ensure the caller cannot modify the original shared plan.
-	return deepcopyPlan(&pm.plan)
+	loadedPlan, err := deepcopyPlan(&pm.plan)
+	if err != nil {
+		return blip.Plan{}, err
+	}
+	if databaseType, ok := pl.monitorTypes[monitorId]; ok {
+		if err := ValidatePlanDatabase(loadedPlan, databaseType); err != nil {
+			return blip.Plan{}, fmt.Errorf("monitor %s: %w", monitorId, err)
+		}
+	}
+	return loadedPlan, nil
 }
 
 func (pl *Loader) SharedPlans() []Meta {
@@ -514,6 +533,8 @@ func ValidatePlans(plans []blip.Plan) error {
 			continue
 		}
 
+		validDomains := true
+
 		// Second level validation: PlanLoader checks that domains exist, and
 		// domain options vs collector help
 		for levelName := range plans[i].Levels {
@@ -532,6 +553,7 @@ func ValidatePlans(plans []blip.Plan) error {
 					var err error
 					mc, err = metrics.Make(domainName, blip.CollectorFactoryArgs{Validate: true})
 					if err != nil {
+						validDomains = false
 						errMsgs = append(errMsgs, fmt.Sprintf("invalid plan: %s: at %s/%s: %s",
 							plans[i].Name, levelName, domainName, err))
 						continue DOMAINS
@@ -551,6 +573,12 @@ func ValidatePlans(plans []blip.Plan) error {
 				}
 			}
 		}
+
+		if validDomains {
+			if err := validatePlanDatabaseCompatibility(plans[i]); err != nil {
+				errMsgs = append(errMsgs, fmt.Sprintf("invalid plan: %s: %s", plans[i].Name, err))
+			}
+		}
 	}
 
 	// Third level validation is each collector Prepare, called by monitor/Engine.Prepare
@@ -559,6 +587,85 @@ func ValidatePlans(plans []blip.Plan) error {
 		return fmt.Errorf("%d plan validation errors:\n%s", len(errMsgs), strings.Join(errMsgs, "\n"))
 	}
 
+	return nil
+}
+
+func validatePlanDatabaseCompatibility(plan blip.Plan) error {
+	domainSet := map[string]struct{}{}
+	for _, level := range plan.Levels {
+		for domain := range level.Collect {
+			domainSet[domain] = struct{}{}
+		}
+	}
+	if len(domainSet) == 0 {
+		return nil
+	}
+
+	domains := make([]string, 0, len(domainSet))
+	for domain := range domainSet {
+		domains = append(domains, domain)
+	}
+	sort.Strings(domains)
+
+	commonTypes := map[blip.DatabaseType]bool{}
+	domainTypes := make([]string, 0, len(domains))
+	for i, domain := range domains {
+		supportedTypes, err := metrics.SupportedDatabaseTypes(domain)
+		if err != nil {
+			return err
+		}
+		domainTypes = append(domainTypes, fmt.Sprintf("%s=%v", domain, supportedTypes))
+
+		supported := map[blip.DatabaseType]bool{}
+		for _, databaseType := range supportedTypes {
+			supported[databaseType] = true
+			if i == 0 {
+				commonTypes[databaseType] = true
+			}
+		}
+		if i == 0 {
+			continue
+		}
+		for databaseType := range commonTypes {
+			if !supported[databaseType] {
+				delete(commonTypes, databaseType)
+			}
+		}
+	}
+
+	if len(commonTypes) == 0 {
+		return fmt.Errorf("collectors have no common database type: %s", strings.Join(domainTypes, ", "))
+	}
+	return nil
+}
+
+// ValidatePlanDatabase returns nil if every collector in the plan supports the
+// monitor's database type. Global plan loading cannot perform this validation
+// because one set of shared plans can serve monitors of different types.
+func ValidatePlanDatabase(plan blip.Plan, databaseType blip.DatabaseType) error {
+	domainSet := map[string]struct{}{}
+	for _, level := range plan.Levels {
+		for domain := range level.Collect {
+			domainSet[domain] = struct{}{}
+		}
+	}
+
+	domains := make([]string, 0, len(domainSet))
+	for domain := range domainSet {
+		domains = append(domains, domain)
+	}
+	sort.Strings(domains)
+
+	errMsgs := []string{}
+	for _, domain := range domains {
+		if err := metrics.ValidateDatabase(domain, databaseType); err != nil {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+	if len(errMsgs) > 0 {
+		return fmt.Errorf("plan %s is incompatible with database type %q:\n%s",
+			plan.Name, databaseType, strings.Join(errMsgs, "\n"))
+	}
 	return nil
 }
 

--- a/plan/loader_test.go
+++ b/plan/loader_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -162,5 +163,152 @@ func TestPlanShouldReturnDeepCopyOfPlan(t *testing.T) {
 			gotDomain := gotCollect[domainKey]
 			assert.NotEqual(t, fmt.Sprintf("%p", expectedDomain.Metrics), fmt.Sprintf("%p", gotDomain.Metrics))
 		}
+	}
+}
+
+type planDatabaseTypesFactory struct {
+	mock.MetricFactory
+	databaseTypes []blip.DatabaseType
+}
+
+func (f planDatabaseTypesFactory) DatabaseTypes(string) []blip.DatabaseType {
+	return f.databaseTypes
+}
+
+func TestSharedPlansValidateDatabaseCompatibilityPerMonitor(t *testing.T) {
+	const (
+		mysqlDomain    = "test.mysql-plan"
+		postgresDomain = "test.postgres-plan"
+		sharedDomain   = "test.shared-plan"
+	)
+	factory := mock.MetricFactory{}
+	if err := metrics.Register(mysqlDomain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(mysqlDomain) })
+	if err := metrics.Register(postgresDomain, planDatabaseTypesFactory{
+		databaseTypes: []blip.DatabaseType{blip.DatabaseTypePostgres},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(postgresDomain) })
+	if err := metrics.Register(sharedDomain, planDatabaseTypesFactory{
+		databaseTypes: []blip.DatabaseType{
+			blip.DatabaseTypeMySQL,
+			blip.DatabaseTypePostgres,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(sharedDomain) })
+
+	newPlan := func(name, databaseDomain string) blip.Plan {
+		return blip.Plan{
+			Name: name,
+			Levels: map[string]blip.Level{
+				"level": {
+					Name: "level",
+					Freq: "1s",
+					Collect: map[string]blip.Domain{
+						databaseDomain: {},
+						sharedDomain:   {},
+					},
+				},
+			},
+		}
+	}
+	mysqlPlan := newPlan("mysql-plan", mysqlDomain)
+	postgresPlan := newPlan("postgres-plan", postgresDomain)
+
+	pl := plan.NewLoader(func(blip.ConfigPlans) ([]blip.Plan, error) {
+		return []blip.Plan{mysqlPlan, postgresPlan}, nil
+	})
+	if err := pl.LoadShared(blip.ConfigPlans{}, nil); err != nil {
+		t.Fatalf("LoadShared: %v", err)
+	}
+
+	// The omitted database type exercises Blip's existing MySQL default.
+	if err := pl.LoadMonitor(blip.ConfigMonitor{MonitorId: "mysql"}, nil); err != nil {
+		t.Fatalf("LoadMonitor(mysql): %v", err)
+	}
+	if err := pl.LoadMonitor(blip.ConfigMonitor{
+		MonitorId:    "postgres",
+		DatabaseType: blip.DatabaseTypePostgres,
+	}, nil); err != nil {
+		t.Fatalf("LoadMonitor(postgres): %v", err)
+	}
+
+	if _, err := pl.Plan("mysql", mysqlPlan.Name, nil); err != nil {
+		t.Fatalf("MySQL plan for MySQL monitor: %v", err)
+	}
+	if _, err := pl.Plan("postgres", postgresPlan.Name, nil); err != nil {
+		t.Fatalf("PostgreSQL plan for PostgreSQL monitor: %v", err)
+	}
+
+	if _, err := pl.Plan("mysql", postgresPlan.Name, nil); err == nil ||
+		!strings.Contains(err.Error(), `collector test.postgres-plan does not support database type "mysql" (supported: [postgres])`) {
+		t.Fatalf("PostgreSQL plan for MySQL monitor error = %v", err)
+	}
+	if _, err := pl.Plan("postgres", mysqlPlan.Name, nil); err == nil ||
+		!strings.Contains(err.Error(), `collector test.mysql-plan does not support database type "postgres" (supported: [mysql])`) {
+		t.Fatalf("MySQL plan for PostgreSQL monitor error = %v", err)
+	}
+}
+
+func TestValidatePlansRejectsCollectorsWithoutCommonDatabaseType(t *testing.T) {
+	const (
+		mysqlDomain    = "test.no-common-mysql"
+		postgresDomain = "test.no-common-postgres"
+		sharedDomain   = "test.no-common-shared"
+	)
+	if err := metrics.Register(mysqlDomain, mock.MetricFactory{}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(mysqlDomain) })
+	if err := metrics.Register(postgresDomain, planDatabaseTypesFactory{
+		databaseTypes: []blip.DatabaseType{blip.DatabaseTypePostgres},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(postgresDomain) })
+	if err := metrics.Register(sharedDomain, planDatabaseTypesFactory{
+		databaseTypes: []blip.DatabaseType{
+			blip.DatabaseTypeMySQL,
+			blip.DatabaseTypePostgres,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(sharedDomain) })
+
+	mixedPlan := blip.Plan{
+		Name: "mixed-database-plan",
+		Levels: map[string]blip.Level{
+			"mysql": {
+				Freq: "1s",
+				Collect: map[string]blip.Domain{
+					mysqlDomain:  {},
+					sharedDomain: {},
+				},
+			},
+			"postgres": {
+				Freq: "5s",
+				Collect: map[string]blip.Domain{
+					postgresDomain: {},
+				},
+			},
+		},
+	}
+
+	err := plan.ValidatePlans([]blip.Plan{mixedPlan})
+	if err == nil {
+		t.Fatal("mixed MySQL and PostgreSQL plan is valid")
+	}
+	expected := "collectors have no common database type: " +
+		"test.no-common-mysql=[mysql], " +
+		"test.no-common-postgres=[postgres], " +
+		"test.no-common-shared=[mysql postgres]"
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("ValidatePlans error = %v", err)
 	}
 }


### PR DESCRIPTION
## Why
Blip can now dispatch database connections by monitor type, but collector registration and plan validation still allow incompatible MySQL and PostgreSQL domains to be combined until runtime.

## What
- Let collector factories optionally declare their supported database types while defaulting legacy factories to MySQL
- Mark built-in SQL collectors as MySQL-only and allow `aws.rds` for MySQL and PostgreSQL
- Reject any plan whose collectors have no common supported database type across all levels
- Validate the selected plan against each monitor effective database type
- Document the factory and plan contracts and add legacy, multi-engine, and mixed-plan regression coverage

## Risk Assessment
Medium — this touches core registry and plan-selection paths on the unreleased integration branch. The `metrics.Register` API and existing MySQL factory behavior remain unchanged, with focused and full regression coverage.

## References
- `go test -race ./metrics ./plan`
- `go test ./...` with the documented MySQL 8.0 fixture
- `go vet ./...`
- pgblip `go test ./...` and `go vet ./...` against this local Blip worktree
- Builds on block/blip#170

Generated with Codex