### PR TITLE
Add monitor-owned database providers

### DIFF
--- a/blip.go
+++ b/blip.go
@@ -218,6 +218,23 @@ type DbFactory interface {
 	Make(ConfigMonitor) (*sql.DB, string, error)
 }
 
+// DbProvider owns the database connections associated with one monitor.
+// Primary returns the connection used by existing Blip subsystems and
+// collectors. Close releases the primary connection and any additional
+// database-specific resources owned by the provider.
+type DbProvider interface {
+	Primary() *sql.DB
+	Close() error
+}
+
+// DbProviderFactory is an optional DbFactory capability for database engines
+// that need to own more than one connection pool per monitor. Blip preserves
+// the existing DbFactory.Make path for factories that do not implement it.
+type DbProviderFactory interface {
+	DbFactory
+	MakeProvider(ConfigMonitor) (DbProvider, string, error)
+}
+
 type HTTPClientFactory interface {
 	MakeForSink(sinkName, monitorId string, opts, tags map[string]string) (*http.Client, error)
 }

--- a/collector.go
+++ b/collector.go
@@ -136,6 +136,15 @@ type CollectorFactory interface {
 	Make(domain string, args CollectorFactoryArgs) (Collector, error)
 }
 
+// CollectorFactoryWithDBProvider is an optional CollectorFactory capability
+// for database-specific collectors that need access to the monitor-owned
+// database provider. Factories that do not implement it retain the historical
+// Make behavior.
+type CollectorFactoryWithDBProvider interface {
+	CollectorFactory
+	MakeWithDBProvider(domain string, args CollectorFactoryArgs, provider DbProvider) (Collector, error)
+}
+
 // CollectorFactoryDatabaseTypes is an optional CollectorFactory capability
 // that identifies the database types supported by a domain. Factories that do
 // not implement this interface retain Blip's historical MySQL behavior.

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -167,6 +167,17 @@ func validateDatabase(domain string, databaseType blip.DatabaseType) error {
 //
 // See types in the blip package for more details.
 func Make(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error) {
+	return makeWithDBProvider(domain, args, nil)
+}
+
+// MakeWithDBProvider makes a collector with an optional monitor-owned database
+// provider. Registered factories without the optional provider capability
+// continue through their historical Make method.
+func MakeWithDBProvider(domain string, args blip.CollectorFactoryArgs, provider blip.DbProvider) (blip.Collector, error) {
+	return makeWithDBProvider(domain, args, provider)
+}
+
+func makeWithDBProvider(domain string, args blip.CollectorFactoryArgs, provider blip.DbProvider) (blip.Collector, error) {
 	r.Lock()
 	defer r.Unlock()
 	registered, ok := r.factory[domain]
@@ -179,6 +190,11 @@ func Make(domain string, args blip.CollectorFactoryArgs) (blip.Collector, error)
 	if !args.Validate {
 		if err := validateDatabase(domain, args.Config.EffectiveDatabaseType()); err != nil {
 			return nil, err
+		}
+	}
+	if provider != nil {
+		if providerFactory, ok := registered.factory.(blip.CollectorFactoryWithDBProvider); ok {
+			return providerFactory.MakeWithDBProvider(domain, args, provider)
 		}
 	}
 	return registered.factory.Make(domain, args)

--- a/metrics/factory_test.go
+++ b/metrics/factory_test.go
@@ -3,6 +3,7 @@
 package metrics_test
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -14,6 +15,34 @@ import (
 type databaseTypesFactory struct {
 	mock.MetricFactory
 	databaseTypes func(string) []blip.DatabaseType
+}
+
+type providerFactory struct {
+	mock.MetricFactory
+	providerCalls int
+	provider      blip.DbProvider
+}
+
+func (f *providerFactory) MakeWithDBProvider(
+	domain string,
+	args blip.CollectorFactoryArgs,
+	provider blip.DbProvider,
+) (blip.Collector, error) {
+	f.providerCalls++
+	f.provider = provider
+	return f.MetricFactory.Make(domain, args)
+}
+
+type testProvider struct {
+	primary *sql.DB
+}
+
+func (p testProvider) Primary() *sql.DB {
+	return p.primary
+}
+
+func (testProvider) Close() error {
+	return nil
 }
 
 func (f databaseTypesFactory) DatabaseTypes(domain string) []blip.DatabaseType {
@@ -175,6 +204,61 @@ func TestRegisterDuplicateDoesNotInspectFactoryDatabaseTypes(t *testing.T) {
 	err := metrics.Register(domain, factory)
 	if err == nil || !strings.Contains(err.Error(), "already registered") {
 		t.Fatalf("Register duplicate error = %v", err)
+	}
+}
+
+func TestMakeWithDBProviderUsesOptionalFactoryCapability(t *testing.T) {
+	const domain = "test.db-provider"
+	makeCalls := 0
+	factory := &providerFactory{
+		MetricFactory: mock.MetricFactory{
+			MakeFunc: func(string, blip.CollectorFactoryArgs) (blip.Collector, error) {
+				makeCalls++
+				return mock.MetricsCollector{}, nil
+			},
+		},
+	}
+	if err := metrics.Register(domain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	provider := testProvider{primary: &sql.DB{}}
+	if _, err := metrics.MakeWithDBProvider(domain, blip.CollectorFactoryArgs{}, provider); err != nil {
+		t.Fatal(err)
+	}
+	if factory.providerCalls != 1 || makeCalls != 1 {
+		t.Fatalf("factory calls: provider=%d Make=%d, expected 1 and 1",
+			factory.providerCalls, makeCalls)
+	}
+	if factory.provider != provider {
+		t.Fatalf("factory provider = %T %p, expected %T %p",
+			factory.provider, factory.provider, provider, provider)
+	}
+}
+
+func TestMakePreservesHistoricalFactoryPath(t *testing.T) {
+	const domain = "test.db-provider-legacy-make"
+	makeCalls := 0
+	factory := &providerFactory{
+		MetricFactory: mock.MetricFactory{
+			MakeFunc: func(string, blip.CollectorFactoryArgs) (blip.Collector, error) {
+				makeCalls++
+				return mock.MetricsCollector{}, nil
+			},
+		},
+	}
+	if err := metrics.Register(domain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	if _, err := metrics.Make(domain, blip.CollectorFactoryArgs{}); err != nil {
+		t.Fatal(err)
+	}
+	if factory.providerCalls != 0 || makeCalls != 1 {
+		t.Fatalf("factory calls: provider=%d Make=%d, expected 0 and 1",
+			factory.providerCalls, makeCalls)
 	}
 }
 

--- a/monitor/engine.go
+++ b/monitor/engine.go
@@ -61,13 +61,10 @@ type Engine struct {
 }
 
 func NewEngine(cfg blip.ConfigMonitor, db *sql.DB) *Engine {
-	return NewEngineWithProvider(cfg, db, nil)
+	return newEngineWithDBProvider(cfg, db, nil)
 }
 
-// NewEngineWithProvider creates an Engine with an optional monitor-owned
-// database provider. NewEngine remains the backward-compatible constructor for
-// callers that only have one database connection.
-func NewEngineWithProvider(cfg blip.ConfigMonitor, db *sql.DB, dbProvider blip.DbProvider) *Engine {
+func newEngineWithDBProvider(cfg blip.ConfigMonitor, db *sql.DB, dbProvider blip.DbProvider) *Engine {
 	return &Engine{
 		cfg:        cfg,
 		db:         db,

--- a/monitor/engine.go
+++ b/monitor/engine.go
@@ -46,9 +46,10 @@ type collection struct {
 // stop/destroy the Engine. Like all Monitor components, an Engine is not restarted
 // or reused, it's recreated if the Monitor is restarted.
 type Engine struct {
-	cfg       blip.ConfigMonitor
-	db        *sql.DB
-	monitorId string
+	cfg        blip.ConfigMonitor
+	db         *sql.DB
+	dbProvider blip.DbProvider
+	monitorId  string
 	// --
 	event event.MonitorReceiver
 	*sync.Mutex
@@ -60,10 +61,18 @@ type Engine struct {
 }
 
 func NewEngine(cfg blip.ConfigMonitor, db *sql.DB) *Engine {
+	return NewEngineWithProvider(cfg, db, nil)
+}
+
+// NewEngineWithProvider creates an Engine with an optional monitor-owned
+// database provider. NewEngine remains the backward-compatible constructor for
+// callers that only have one database connection.
+func NewEngineWithProvider(cfg blip.ConfigMonitor, db *sql.DB, dbProvider blip.DbProvider) *Engine {
 	return &Engine{
-		cfg:       cfg,
-		db:        db,
-		monitorId: cfg.MonitorId,
+		cfg:        cfg,
+		db:         db,
+		dbProvider: dbProvider,
+		monitorId:  cfg.MonitorId,
 		// --
 		event:          event.MonitorReceiver{MonitorId: cfg.MonitorId},
 		Mutex:          &sync.Mutex{},
@@ -143,13 +152,14 @@ func (e *Engine) Prepare(ctx context.Context, plan blip.Plan, before, after func
 			if _, ok := collectors[domain]; ok {
 				continue // already seen
 			}
-			c, err := metrics.Make(
+			c, err := metrics.MakeWithDBProvider(
 				domain,
 				blip.CollectorFactoryArgs{
 					Config:    e.cfg,
 					DB:        e.db,
 					MonitorId: e.monitorId,
 				},
+				e.dbProvider,
 			)
 			if err != nil {
 				lerr = fmt.Errorf("while making %s collector: %s", domain, err)

--- a/monitor/level_collector.go
+++ b/monitor/level_collector.go
@@ -78,13 +78,10 @@ type LevelCollectorArgs struct {
 }
 
 func NewLevelCollector(args LevelCollectorArgs) *lco {
-	return NewLevelCollectorWithDBProvider(args, nil)
+	return newLevelCollectorWithDBProvider(args, nil)
 }
 
-// NewLevelCollectorWithDBProvider creates a level collector with an optional
-// monitor-owned database provider. NewLevelCollector remains the
-// backward-compatible constructor for single-connection callers.
-func NewLevelCollectorWithDBProvider(args LevelCollectorArgs, dbProvider blip.DbProvider) *lco {
+func newLevelCollectorWithDBProvider(args LevelCollectorArgs, dbProvider blip.DbProvider) *lco {
 	return &lco{
 		cfg:              args.Config,
 		planLoader:       args.PlanLoader,
@@ -92,7 +89,7 @@ func NewLevelCollectorWithDBProvider(args LevelCollectorArgs, dbProvider blip.Db
 		transformMetrics: args.TransformMetrics,
 		// --
 		monitorId:   args.Config.MonitorId,
-		engine:      NewEngineWithProvider(args.Config, args.DB, dbProvider),
+		engine:      newEngineWithDBProvider(args.Config, args.DB, dbProvider),
 		stateMux:    &sync.Mutex{},
 		paused:      true,
 		changeMux:   &sync.Mutex{},

--- a/monitor/level_collector.go
+++ b/monitor/level_collector.go
@@ -78,6 +78,13 @@ type LevelCollectorArgs struct {
 }
 
 func NewLevelCollector(args LevelCollectorArgs) *lco {
+	return NewLevelCollectorWithDBProvider(args, nil)
+}
+
+// NewLevelCollectorWithDBProvider creates a level collector with an optional
+// monitor-owned database provider. NewLevelCollector remains the
+// backward-compatible constructor for single-connection callers.
+func NewLevelCollectorWithDBProvider(args LevelCollectorArgs, dbProvider blip.DbProvider) *lco {
 	return &lco{
 		cfg:              args.Config,
 		planLoader:       args.PlanLoader,
@@ -85,7 +92,7 @@ func NewLevelCollector(args LevelCollectorArgs) *lco {
 		transformMetrics: args.TransformMetrics,
 		// --
 		monitorId:   args.Config.MonitorId,
-		engine:      NewEngine(args.Config, args.DB),
+		engine:      NewEngineWithProvider(args.Config, args.DB, dbProvider),
 		stateMux:    &sync.Mutex{},
 		paused:      true,
 		changeMux:   &sync.Mutex{},

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -58,13 +58,14 @@ type Monitor struct {
 	transformMetric func([]*blip.Metrics) error
 
 	// Core components
-	runMux  *sync.RWMutex
-	db      *sql.DB
-	dsn     string // redacted (no password)
-	promAPI *prom.API
-	lco     LevelCollector
-	pch     PlanChanger
-	hbw     *heartbeat.Writer
+	runMux     *sync.RWMutex
+	db         *sql.DB
+	dbProvider blip.DbProvider
+	dsn        string // redacted (no password)
+	promAPI    *prom.API
+	lco        LevelCollector
+	pch        PlanChanger
+	hbw        *heartbeat.Writer
 
 	// Control chans and sync
 	runLoopChan chan struct{} // Stop(): stop the monitor
@@ -150,10 +151,8 @@ func (m *Monitor) Stop() error {
 	// Stop and wait for monitor subsystems
 	m.stop(false, "Stop")
 
-	// Everything should be stopped now, so close db connection
-	if m.db != nil {
-		m.db.Close()
-	}
+	// Everything should be stopped now, so close database resources.
+	m.closeDB()
 
 	event.Sendf(event.MONITOR_STOPPED, "%s", m.monitorId)
 	status.Monitor(m.monitorId, status.MONITOR, "stopped at %s", blip.FormatTime(time.Now()))
@@ -249,15 +248,22 @@ func (m *Monitor) startup() error {
 	// DB-plan loop
 	// //////////////////////////////////////////////////////////////////////
 
+	// Release database resources from an earlier failed startup or subsystem
+	// restart before creating the next monitor-owned connection set.
+	m.runMux.Lock()
+	m.closeDB()
+	m.runMux.Unlock()
+
 	// ----------------------------------------------------------------------
 	// Make DSN and *sql.DB. This does NOT connect to MySQL.
 	for {
 		status.Monitor(m.monitorId, status.MONITOR, "making DB/DSN (not connecting)")
-		db, dsnRedacted, err := m.dbMaker.Make(m.cfg)
+		dbProvider, db, dsnRedacted, err := m.makeDB()
 		m.setErr(err, false)
 		if err == nil { // success
 			m.runMux.Lock()
 			m.db = db
+			m.dbProvider = dbProvider
 			m.dsn = dsnRedacted
 			status.Monitor(m.monitorId, status.MONITOR_DSN, "%s", dsnRedacted)
 			m.runMux.Unlock()
@@ -352,7 +358,7 @@ func (m *Monitor) startup() error {
 		m.promAPI = prom.NewAPI(
 			m.cfg.Exporter,
 			m.monitorId,
-			NewExporter(m.cfg.Exporter, promPlan, NewEngine(m.cfg, m.db)),
+			NewExporter(m.cfg.Exporter, promPlan, NewEngineWithProvider(m.cfg, m.db, m.dbProvider)),
 		)
 
 		m.wg.Add(1)
@@ -391,13 +397,13 @@ func (m *Monitor) startup() error {
 	// config.plans.change, then it will do this; if it's not enabled,
 	// we'll do it as the last startup step.
 	status.Monitor(m.monitorId, status.MONITOR, "starting level collector")
-	m.lco = NewLevelCollector(LevelCollectorArgs{
+	m.lco = NewLevelCollectorWithDBProvider(LevelCollectorArgs{
 		Config:           m.cfg,
 		DB:               m.db,
 		PlanLoader:       m.planLoader,
 		Sinks:            m.sinks,
 		TransformMetrics: m.transformMetric,
-	})
+	}, m.dbProvider)
 
 	m.wg.Add(1)
 	go func() {
@@ -456,6 +462,46 @@ func (m *Monitor) startup() error {
 	return nil
 }
 
+func (m *Monitor) makeDB() (blip.DbProvider, *sql.DB, string, error) {
+	providerFactory, ok := m.dbMaker.(blip.DbProviderFactory)
+	if !ok {
+		db, dsn, err := m.dbMaker.Make(m.cfg)
+		return nil, db, dsn, err
+	}
+
+	provider, dsn, err := providerFactory.MakeProvider(m.cfg)
+	if err != nil {
+		if provider != nil {
+			provider.Close()
+		}
+		return nil, nil, "", err
+	}
+	if provider == nil {
+		return nil, nil, "", fmt.Errorf("database provider factory returned a nil provider")
+	}
+	db := provider.Primary()
+	if db == nil {
+		provider.Close()
+		return nil, nil, "", fmt.Errorf("database provider returned a nil primary connection")
+	}
+	return provider, db, dsn, nil
+}
+
+// closeDB releases the current monitor-owned database resources. The caller
+// must hold runMux.
+func (m *Monitor) closeDB() {
+	if m.dbProvider != nil {
+		m.dbProvider.Close()
+		m.dbProvider = nil
+		m.db = nil
+		return
+	}
+	if m.db != nil {
+		m.db.Close()
+		m.db = nil
+	}
+}
+
 // stop stops the monitor subsystems started in startup. It does not stop the
 // monitor; Stop does that. Stopping only the monitor subsystems causes runLoop
 // to restart them.
@@ -487,6 +533,11 @@ func (m *Monitor) stop(lock bool, caller string) {
 	// Wait for monitor subsystem goroutines to return
 	status.Monitor(m.monitorId, status.MONITOR, "stopping goroutines")
 	m.wg.Wait()
+
+	// A subsystem failure restarts the whole monitor, including its database
+	// provider. Close the current provider only after every subsystem has
+	// stopped using its connections.
+	m.closeDB()
 }
 
 func (m *Monitor) setErr(err error, isPanic bool) {

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -358,7 +358,7 @@ func (m *Monitor) startup() error {
 		m.promAPI = prom.NewAPI(
 			m.cfg.Exporter,
 			m.monitorId,
-			NewExporter(m.cfg.Exporter, promPlan, NewEngineWithProvider(m.cfg, m.db, m.dbProvider)),
+			NewExporter(m.cfg.Exporter, promPlan, newEngineWithDBProvider(m.cfg, m.db, m.dbProvider)),
 		)
 
 		m.wg.Add(1)
@@ -397,7 +397,7 @@ func (m *Monitor) startup() error {
 	// config.plans.change, then it will do this; if it's not enabled,
 	// we'll do it as the last startup step.
 	status.Monitor(m.monitorId, status.MONITOR, "starting level collector")
-	m.lco = NewLevelCollectorWithDBProvider(LevelCollectorArgs{
+	m.lco = newLevelCollectorWithDBProvider(LevelCollectorArgs{
 		Config:           m.cfg,
 		DB:               m.db,
 		PlanLoader:       m.planLoader,

--- a/monitor/provider_test.go
+++ b/monitor/provider_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 Block, Inc.
+
+package monitor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cashapp/blip"
+	"github.com/cashapp/blip/metrics"
+	"github.com/cashapp/blip/test"
+	"github.com/cashapp/blip/test/mock"
+)
+
+func TestMonitorMakeDBUsesProviderFactory(t *testing.T) {
+	primary := &sql.DB{}
+	provider := &testDBProvider{primary: primary}
+	factory := &testDBProviderFactory{
+		provider: provider,
+		dsn:      "redacted",
+	}
+	monitor := NewMonitor(MonitorArgs{
+		Config:  blip.ConfigMonitor{MonitorId: "provider"},
+		DbMaker: factory,
+	})
+
+	gotProvider, gotPrimary, gotDSN, err := monitor.makeDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotProvider != provider {
+		t.Fatalf("provider = %T %p, expected %T %p", gotProvider, gotProvider, provider, provider)
+	}
+	if gotPrimary != primary {
+		t.Fatalf("primary = %p, expected %p", gotPrimary, primary)
+	}
+	if gotDSN != "redacted" {
+		t.Fatalf("DSN = %q, expected redacted", gotDSN)
+	}
+	if factory.makeCalls != 0 || factory.makeProviderCalls != 1 {
+		t.Fatalf("factory calls: Make=%d MakeProvider=%d, expected 0 and 1",
+			factory.makeCalls, factory.makeProviderCalls)
+	}
+}
+
+func TestMonitorMakeDBPreservesLegacyFactory(t *testing.T) {
+	primary := &sql.DB{}
+	factory := &testLegacyDBFactory{primary: primary, dsn: "legacy"}
+	monitor := NewMonitor(MonitorArgs{
+		Config:  blip.ConfigMonitor{MonitorId: "legacy"},
+		DbMaker: factory,
+	})
+
+	provider, gotPrimary, gotDSN, err := monitor.makeDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider != nil {
+		t.Fatalf("legacy factory returned provider %T, expected nil", provider)
+	}
+	if gotPrimary != primary || gotDSN != "legacy" {
+		t.Fatalf("legacy result = (%p, %q), expected (%p, legacy)", gotPrimary, gotDSN, primary)
+	}
+}
+
+func TestMonitorMakeDBRejectsInvalidProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   blip.DbProvider
+		factoryErr error
+		wantError  string
+	}{
+		{
+			name:       "factory error",
+			provider:   &testDBProvider{primary: &sql.DB{}},
+			factoryErr: errors.New("make failed"),
+			wantError:  "make failed",
+		},
+		{
+			name:      "nil provider",
+			wantError: "nil provider",
+		},
+		{
+			name:      "nil primary",
+			provider:  &testDBProvider{},
+			wantError: "nil primary",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			factory := &testDBProviderFactory{
+				provider: test.provider,
+				err:      test.factoryErr,
+			}
+			monitor := NewMonitor(MonitorArgs{
+				Config:  blip.ConfigMonitor{MonitorId: test.name},
+				DbMaker: factory,
+			})
+
+			_, _, _, err := monitor.makeDB()
+			if err == nil || !errors.Is(err, test.factoryErr) && !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("makeDB error = %v, expected %q", err, test.wantError)
+			}
+			if provider, ok := test.provider.(*testDBProvider); ok && provider.closeCalls != 1 {
+				t.Fatalf("provider Close calls = %d, expected 1", provider.closeCalls)
+			}
+		})
+	}
+}
+
+func TestMonitorCloseDBClosesProviderOnce(t *testing.T) {
+	provider := &testDBProvider{primary: &sql.DB{}}
+	monitor := &Monitor{
+		db:         provider.primary,
+		dbProvider: provider,
+	}
+
+	monitor.closeDB()
+	monitor.closeDB()
+
+	if provider.closeCalls != 1 {
+		t.Fatalf("provider Close calls = %d, expected 1", provider.closeCalls)
+	}
+	if monitor.db != nil || monitor.dbProvider != nil {
+		t.Fatalf("monitor retained database resources: db=%p provider=%T", monitor.db, monitor.dbProvider)
+	}
+}
+
+func TestNewEngineWithProviderRetainsProvider(t *testing.T) {
+	provider := &testDBProvider{primary: &sql.DB{}}
+	engine := NewEngineWithProvider(blip.ConfigMonitor{MonitorId: "engine"}, provider.primary, provider)
+
+	if engine.DB() != provider.primary {
+		t.Fatalf("engine primary = %p, expected %p", engine.DB(), provider.primary)
+	}
+	if engine.dbProvider != provider {
+		t.Fatalf("engine provider = %T %p, expected %T %p", engine.dbProvider, engine.dbProvider, provider, provider)
+	}
+}
+
+func TestEnginePassesProviderToCollectorFactory(t *testing.T) {
+	_, db, err := test.Connection(test.DefaultMySQLVersion)
+	if err != nil {
+		if test.Build {
+			t.Skip("MySQL test fixture not running")
+		}
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	const domain = "test.db-provider"
+	provider := &testDBProvider{primary: db}
+	factory := &testProviderCollectorFactory{domain: domain}
+	if err := metrics.Register(domain, factory); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { metrics.Remove(domain) })
+
+	engine := NewEngineWithProvider(
+		blip.ConfigMonitor{MonitorId: "provider-engine"},
+		db,
+		provider,
+	)
+	plan := blip.Plan{
+		Name: "provider",
+		Levels: map[string]blip.Level{
+			"fast": {
+				Name: "fast",
+				Freq: "1s",
+				Collect: map[string]blip.Domain{
+					domain: {},
+				},
+			},
+		},
+	}
+	if err := engine.Prepare(context.Background(), plan, func() {}, func() {}); err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Stop()
+
+	if factory.provider != provider {
+		t.Fatalf("collector provider = %T %p, expected %T %p",
+			factory.provider, factory.provider, provider, provider)
+	}
+	if factory.makeCalls != 0 || factory.makeProviderCalls != 1 {
+		t.Fatalf("collector factory calls: Make=%d MakeWithDBProvider=%d, expected 0 and 1",
+			factory.makeCalls, factory.makeProviderCalls)
+	}
+}
+
+type testDBProvider struct {
+	primary    *sql.DB
+	closeCalls int
+}
+
+func (p *testDBProvider) Primary() *sql.DB {
+	return p.primary
+}
+
+func (p *testDBProvider) Close() error {
+	p.closeCalls++
+	return nil
+}
+
+type testDBProviderFactory struct {
+	provider          blip.DbProvider
+	dsn               string
+	err               error
+	makeCalls         int
+	makeProviderCalls int
+}
+
+func (f *testDBProviderFactory) Make(blip.ConfigMonitor) (*sql.DB, string, error) {
+	f.makeCalls++
+	return nil, "", errors.New("legacy Make should not be called")
+}
+
+func (f *testDBProviderFactory) MakeProvider(blip.ConfigMonitor) (blip.DbProvider, string, error) {
+	f.makeProviderCalls++
+	return f.provider, f.dsn, f.err
+}
+
+type testLegacyDBFactory struct {
+	primary *sql.DB
+	dsn     string
+}
+
+func (f *testLegacyDBFactory) Make(blip.ConfigMonitor) (*sql.DB, string, error) {
+	return f.primary, f.dsn, nil
+}
+
+type testProviderCollectorFactory struct {
+	domain            string
+	provider          blip.DbProvider
+	makeCalls         int
+	makeProviderCalls int
+}
+
+func (f *testProviderCollectorFactory) Make(string, blip.CollectorFactoryArgs) (blip.Collector, error) {
+	f.makeCalls++
+	return nil, errors.New("legacy Make should not be called")
+}
+
+func (f *testProviderCollectorFactory) MakeWithDBProvider(
+	domain string,
+	_ blip.CollectorFactoryArgs,
+	provider blip.DbProvider,
+) (blip.Collector, error) {
+	f.makeProviderCalls++
+	f.provider = provider
+	if domain != f.domain {
+		return nil, fmt.Errorf("collector domain = %q, expected %q", domain, f.domain)
+	}
+	return mock.MetricsCollector{DomainFunc: func() string { return domain }}, nil
+}

--- a/monitor/provider_test.go
+++ b/monitor/provider_test.go
@@ -131,9 +131,9 @@ func TestMonitorCloseDBClosesProviderOnce(t *testing.T) {
 	}
 }
 
-func TestNewEngineWithProviderRetainsProvider(t *testing.T) {
+func TestNewEngineWithDBProviderRetainsProvider(t *testing.T) {
 	provider := &testDBProvider{primary: &sql.DB{}}
-	engine := NewEngineWithProvider(blip.ConfigMonitor{MonitorId: "engine"}, provider.primary, provider)
+	engine := newEngineWithDBProvider(blip.ConfigMonitor{MonitorId: "engine"}, provider.primary, provider)
 
 	if engine.DB() != provider.primary {
 		t.Fatalf("engine primary = %p, expected %p", engine.DB(), provider.primary)
@@ -161,7 +161,7 @@ func TestEnginePassesProviderToCollectorFactory(t *testing.T) {
 	}
 	t.Cleanup(func() { metrics.Remove(domain) })
 
-	engine := NewEngineWithProvider(
+	engine := newEngineWithDBProvider(
 		blip.ConfigMonitor{MonitorId: "provider-engine"},
 		db,
 		provider,


### PR DESCRIPTION
## Why
PostgreSQL monitors need to own additional per-database connection pools while preserving Blip’s existing single-pool behavior for current users.

## What
- Add an optional monitor-owned database provider lifecycle
- Forward providers to collectors through an optional factory capability
- Preserve existing database factories, collector factories, constructors, and exported argument shapes
- Keep provider-aware Engine and LevelCollector construction internal
- Close provider resources safely across monitor stop and restart paths

## Risk Assessment
Medium — this touches the shared monitor lifecycle, but the new behavior is capability-gated and legacy factories remain on their existing paths. Full tests against MySQL 8.0 and 8.4, race tests, vet, and Codex review passed.

## References
- Builds on #172
- Companion: https://github.com/squareup/pgblip/pull/18

Generated with Codex