### PR TITLE
Release v2.1.0

### DIFF
--- a/blip.go
+++ b/blip.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-const VERSION = "2.0.1"
+const VERSION = "2.1.0"
 
 var SHA = ""
 

--- a/docs/content/about/production-readiness.md
+++ b/docs/content/about/production-readiness.md
@@ -19,7 +19,7 @@ Feature readiness is documented here to help you make informed decisions about m
 
 ## v2.x
 
-Blip v2.x is Stable. Existing production-ready components retain their readiness; collectors introduced in v2.0 are marked New.
+Blip v2.x is Stable. Existing production-ready components retain their readiness; collectors and extension APIs introduced in v2.1 are marked New.
 
 ### Metric Collectors
 
@@ -68,6 +68,7 @@ Blip v2.x is Stable. Existing production-ready components retain their readiness
 |Feature|Readiness|
 |-------|------|
 |[API]({{< ref "api" >}})|Stable|
+|[External database modules]({{< ref "develop/database-modules" >}})|New|
 |[Heartbeat]({{< ref "config/heartbeat" >}})|Stable|
 |[Monitor Loading Stop-loss]({{< ref "monitors/loading#stop-loss" >}})|New|
 |[Plan Changing]({{< ref "plans/changing" >}})|New|

--- a/docs/content/about/release-notes.md
+++ b/docs/content/about/release-notes.md
@@ -2,15 +2,15 @@
 weight: 0
 ---
 
-## v2.0
+## v2
 
-This is a new major version. It added new metric domains, runtime debug controls, extensible AWS Secrets Manager parsing, and a more resilient Datadog delivery path.
+This is a new major version. It added external database module support, new metric domains, runtime debug controls, extensible AWS Secrets Manager parsing, and a more resilient Datadog delivery path.
 
 As described in the [Blip versioning guidelines](https://github.com/block/blip/blob/main/CONTRIBUTING.md#versioning), this series is not entirely backwards-compatible with v1.2. Integrations that use the affected exported APIs must be updated before upgrading.
 
 ### Integration API changes
 
-|Component|v1.2|v2.0|
+|Component|v1.2|v2|
 |---------|----|----|
 |AWS secret password helper|`aws.Secret.Password(context.Context) (string, error)`|Removed; use `GetSecret` or `GetSecretPayload`|
 |Database credential type|`dbconn.Credentials`|`blip.DbCredentials`|
@@ -23,7 +23,7 @@ As described in the [Blip versioning guidelines](https://github.com/block/blip/b
 
 To upgrade an integration:
 
-1. Update imports from `github.com/cashapp/blip/...` to `github.com/cashapp/blip/v2/...` and require `github.com/cashapp/blip/v2 v2.0.1` or later.
+1. Update imports from `github.com/cashapp/blip/...` to `github.com/cashapp/blip/v2/...` and require `github.com/cashapp/blip/v2 v2.1.0` or later.
 2. Replace `dbconn.Credentials` with `blip.DbCredentials` and update any `dbconn.CredentialFunc` implementations.
 3. Accept the new variadic options argument when storing or wrapping `dbconn.NewConnFactory`; ordinary two-argument calls continue to compile.
 4. Capture the parameter slice returned by `DataSizeQuery`, `TableSizeQuery`, and `TableIoWaitQuery`, and pass it to the database query call.
@@ -36,11 +36,15 @@ AWS Secrets Manager `password-secret` authentication now uses the secret's optio
 
 Default sink HTTP clients now have a 10-second whole-request timeout plus bounded connection and response-header timeouts. Custom HTTP client factories are unchanged.
 
-### v2.0.1 (7 Aug 2026)
+### v2.1.0 (10 Aug 2026)
 
-Version v2.0.0 was withdrawn before release completion because its module path lacked the `/v2` suffix required by Go modules. v2.0.1 is the first usable v2 release.
+Version v2.0.0 was withdrawn before release completion because its module path lacked the `/v2` suffix required by Go modules. v2.1.0 is the first usable v2 release.
 
 * Added the required `/v2` module and import path for the v2 series.
+* Added opt-in external database module registration with opaque module-owned configuration and strict validation.
+* Added composable database providers, engine-neutral credential callbacks, and collector access to monitor-owned database resources.
+* Added collector database compatibility metadata and plan validation against each monitor's database type.
+* Hardened monitor teardown to stop collectors before releasing database providers.
 * Added the `autoinc` domain for auto-increment column utilization.
 * Added the `error.account`, `error.global`, `error.host`, `error.thread`, and `error.user` domains.
 * Added the `innodb.buffer-pool` domain.
@@ -51,6 +55,7 @@ Version v2.0.0 was withdrawn before release completion because its module path l
 * Preserved complete metric metadata and isolated counter state in the delta sink.
 * Redacted database, sink, and authenticated proxy credentials from debug logs.
 * Fixed query construction to use driver parameter interpolation across collectors and heartbeats.
+* Fixed interpolation of multiple environment and monitor placeholders in one value.
 * Fixed nondeterministic `query.response-time` bucket selection and added detailed latency diagnostics.
 * Fixed a shutdown panic in signal handling.
 * Updated the test matrix from MySQL 5.7 to MySQL 8.4 and refreshed dependencies.

--- a/docs/content/metrics/domains/autoinc/_index.md
+++ b/docs/content/metrics/domains/autoinc/_index.md
@@ -68,4 +68,4 @@ None.
 
 |Blip Version|Change|
 |------------|------|
-|v2.0.1|Domain added|
+|v2.1.0|Domain added|

--- a/docs/content/metrics/quick-ref.md
+++ b/docs/content/metrics/quick-ref.md
@@ -12,18 +12,18 @@ The rest are reserved for future use.
 |access.index|Index access statistics (`sys.schema_index_statistics`)||
 |access.table|Table access statistics (`sys.schema_table_statistics`)||
 |aria|MariaDB Aria storage engine||
-|[`autoinc`](domains#autoinc)|Auto-increment column utilization|v2.0.1|
+|[`autoinc`](domains#autoinc)|Auto-increment column utilization|v2.1.0|
 |aws|Amazon Web Services||
 |[`aws.rds`](domains#awsrds)|[Amazon RDS metrics](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/monitoring-cloudwatch.html#rds-metrics)|v1.0.0|
 |aws.aurora|Amazon Aurora||
 |azure|Microsoft Azure||
 |error|MySQL, client, and query errors||
 |error.client|Client errors||
-|[error.account](domains#error.account)|Error counts and rates by account [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.0.1|
-|[error.global](domains#error.global)|Global error counts and rates [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.0.1|
-|[error.host](domains#error.host)|Error counts and rates by host [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.0.1|
-|[error.thread](domains#error.thread)|Error counts and rates by thread [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.0.1|
-|[error.user](domains#error.user)|Error counts and rates by user [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.0.1|
+|[error.account](domains#error.account)|Error counts and rates by account [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.1.0|
+|[error.global](domains#error.global)|Global error counts and rates [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.1.0|
+|[error.host](domains#error.host)|Error counts and rates by host [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.1.0|
+|[error.thread](domains#error.thread)|Error counts and rates by thread [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.1.0|
+|[error.user](domains#error.user)|Error counts and rates by user [`Error Summary Tables`](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-error-summary-tables.html)|v2.1.0|
 |error.query|Query errors||
 |error.repl|Replication errors||
 |event|[MySQL Event Scheduler](https://dev.mysql.com/doc/refman/8.0/en/event-scheduler.html)||
@@ -33,7 +33,7 @@ The rest are reserved for future use.
 |gr|MySQL Group Replication||
 |host|Host (client)||
 |[`innodb`](domains#innodb)|InnoDB metrics [`INFORMATION_SCHEMA.INNODB_METRICS`](https://dev.mysql.com/doc/refman/en/information-schema-innodb-metrics-table.html)|v1.0.0|
-|[`innodb.buffer-pool`](domains#innodbbuffer-pool)|InnoDB buffer pool metrics [`INFORMATION_SCHEMA.INNODB_BUFFER_POOL_STATS`](https://dev.mysql.com/doc/refman/8.4/en/information-schema-innodb-buffer-pool-stats-table.html)|v2.0.1|
+|[`innodb.buffer-pool`](domains#innodbbuffer-pool)|InnoDB buffer pool metrics [`INFORMATION_SCHEMA.INNODB_BUFFER_POOL_STATS`](https://dev.mysql.com/doc/refman/8.4/en/information-schema-innodb-buffer-pool-stats-table.html)|v2.1.0|
 |innodb.mutex|InnoDB mutexes `SHOW ENGINE INNODB MUTEX`||
 |mariadb|MariaDB enhancements||
 |ndb|MySQL NDB Cluster||

--- a/examples/copy-meta/go.mod
+++ b/examples/copy-meta/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/cashapp/blip/v2 => ../../
 
-require github.com/cashapp/blip/v2 v2.0.1
+require github.com/cashapp/blip/v2 v2.1.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.20.3 // indirect

--- a/examples/custom-receiver/go.mod
+++ b/examples/custom-receiver/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/cashapp/blip/v2 => ../../
 
-require github.com/cashapp/blip/v2 v2.0.1
+require github.com/cashapp/blip/v2 v2.1.0
 
 require (
 	filippo.io/edwards25519 v1.1.1 // indirect

--- a/examples/custom-sink/go.mod
+++ b/examples/custom-sink/go.mod
@@ -5,7 +5,7 @@ go 1.24
 replace github.com/cashapp/blip/v2 => ../../
 
 require (
-	github.com/cashapp/blip/v2 v2.0.1
+	github.com/cashapp/blip/v2 v2.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/examples/integrate/go.mod
+++ b/examples/integrate/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/cashapp/blip/v2 => ../../
 
-require github.com/cashapp/blip/v2 v2.0.1
+require github.com/cashapp/blip/v2 v2.1.0
 
 require (
 	filippo.io/edwards25519 v1.1.1 // indirect


### PR DESCRIPTION
## Why

Blip v2 needs a publishable release after v2.0.0 was withdrawn for the missing `/v2` module path. With external database module support now merged, v2.1.0 can be the first usable v2 release without immediately creating a separate v3 series.

## What changed

- Set the Blip version and standalone example module requirements to v2.1.0.
- Publish combined v2 release notes, including the external database module framework merged in #176.
- Update feature readiness and metric introduction versions for the first usable v2 release.

## Risk

Low. This PR changes release metadata and documentation only; it does not change runtime behavior.

## References

- #176
- #179
- [Release checklist](https://github.com/block/blip/blob/main/RELEASE.md)

Generated with Codex